### PR TITLE
Add unit tests and fix bugs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     "require-dev": {
         "cakephp/cakephp": "^3.6",
         "phpunit/phpunit": "^5.7 || ^6.0",
-        "php-coveralls/php-coveralls": "^2.2"
+        "php-coveralls/php-coveralls": "^2.2",
+        "nilportugues/sql-query-formatter": "^1.2"
     },
     "scripts": {
         "test": "phpunit"

--- a/src/Database/SqliteCompiler.php
+++ b/src/Database/SqliteCompiler.php
@@ -27,7 +27,7 @@ class SqliteCompiler extends BaseSqliteCompiler
             $p['query'] = $p['query']->sql($generator);
             $p['query'] = $p['query'][0] === '(' ? trim($p['query'], '()') : $p['query'];
             $prefix = $p['all'] ? 'ALL ' : '';
-            return sprintf("%sSELECT * FROM(%s)", $prefix, $p['query']);
+            return sprintf("%sSELECT * FROM (%s)", $prefix, $p['query']);
         }, $parts);
 
         return sprintf(")\nUNION %s", implode("\nUNION ", $parts));

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -210,6 +210,10 @@ class Query extends BaseQuery
             $this->_paginator->limit((int)$sql);
             return;
         }
+
+        // @codeCoverageIgnoreStart
+        throw new \LogicException('Unreachable here');
+        // @codeCoverageIgnoreEnd
     }
 
     /**
@@ -240,8 +244,6 @@ class Query extends BaseQuery
      */
     public function __debugInfo()
     {
-        $eagerLoader = $this->getEagerLoader();
-
         try {
             $info = $this->_paginator->build($this->_cursor)->__debugInfo();
         } catch (InsufficientConstraintsException $e) {
@@ -255,8 +257,8 @@ class Query extends BaseQuery
                 'buffered' => $this->_useBufferedResults,
                 'formatters' => count($this->_formatters),
                 'mapReducers' => count($this->_mapReduce),
-                'contain' => $eagerLoader ? $eagerLoader->getContain() : [],
-                'matching' => $eagerLoader ? $eagerLoader->getMatching() : [],
+                'contain' => $this->_eagerLoader ? $this->_eagerLoader->getContain() : [],
+                'matching' => $this->_eagerLoader ? $this->_eagerLoader->getMatching() : [],
                 'extraOptions' => $this->_options,
                 'repository' => $this->_repository,
             ];

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -10,6 +10,9 @@ use Cake\ORM\Query as BaseQuery;
 use Lampager\Cake\PaginationResult;
 use Lampager\Cake\Paginator;
 use Lampager\Contracts\Cursor;
+use Lampager\Exceptions\Query\BadKeywordException;
+use Lampager\Exceptions\Query\InsufficientConstraintsException;
+use Lampager\Exceptions\Query\LimitParameterException;
 
 /**
  * @method $this forward(bool $forward = true) Define that the current pagination is going forward.
@@ -131,7 +134,7 @@ class Query extends BaseQuery
      */
     protected function _performCount()
     {
-        return $this->_paginator->build($this->_cursor)->_performCount();
+        return $this->all()->count();
     }
 
     /**
@@ -160,7 +163,7 @@ class Query extends BaseQuery
                 $generator->resetCount();
 
                 if (!preg_match('/ (?<direction>ASC|DESC)$/', $condition->sql($generator), $matches)) {
-                    throw new \LogicException('OrderClauseExpression does not have direction');
+                    throw new BadKeywordException('OrderClauseExpression does not have direction');
                 }
 
                 /** @var string $direction */
@@ -198,7 +201,13 @@ class Query extends BaseQuery
         if ($limit instanceof QueryExpression) {
             $generator = $this->getValueBinder();
             $generator->resetCount();
-            $this->_paginator->limit($limit->sql($generator));
+            $sql = $limit->sql($generator);
+
+            if (!ctype_digit($sql) || $sql <= 0) {
+                throw new LimitParameterException('Limit must be positive integer');
+            }
+
+            $this->_paginator->limit((int)$sql);
             return;
         }
     }
@@ -231,9 +240,31 @@ class Query extends BaseQuery
      */
     public function __debugInfo()
     {
+        $eagerLoader = $this->getEagerLoader();
+
+        try {
+            $info = $this->_paginator->build($this->_cursor)->__debugInfo();
+        } catch (InsufficientConstraintsException $e) {
+            $info = [
+                'sql' => 'SQL could not be generated for this query as it is incomplete: ' . $e->getMessage(),
+                'params' => [],
+                'defaultTypes' => $this->getDefaultTypes(),
+                'decorators' => count($this->_resultDecorators),
+                'executed' => (bool)$this->_iterator,
+                'hydrate' => $this->_hydrate,
+                'buffered' => $this->_useBufferedResults,
+                'formatters' => count($this->_formatters),
+                'mapReducers' => count($this->_mapReduce),
+                'contain' => $eagerLoader ? $eagerLoader->getContain() : [],
+                'matching' => $eagerLoader ? $eagerLoader->getMatching() : [],
+                'extraOptions' => $this->_options,
+                'repository' => $this->_repository,
+            ];
+        }
+
         return [
             '(help)' => 'This is a Lampager Query object to get the paginated results.',
             'paginator' => $this->_paginator,
-        ] + $this->_paginator->build($this->_cursor)->__debugInfo();
+        ] + $info;
     }
 }

--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -3,6 +3,7 @@
 namespace Lampager\Cake;
 
 use Cake\ORM\Table;
+use Cake\ORM\Query as CakeQuery;
 use Lampager\Cake\ORM\Query;
 use Lampager\Cake\PaginationResult;
 use Lampager\Concerns\HasProcessor;
@@ -26,7 +27,7 @@ class Paginator extends BasePaginator
     /**
      * Create paginator.
      *
-     * @param Query $builder
+     * @param  Query  $builder
      * @return static
      */
     public static function create(Query $builder)
@@ -49,7 +50,7 @@ class Paginator extends BasePaginator
      * Build CakePHP Query instance from Lampager Query config.
      *
      * @param  LampagerQuery $query
-     * @return Query
+     * @return CakeQuery
      */
     public function transform(LampagerQuery $query)
     {
@@ -60,7 +61,7 @@ class Paginator extends BasePaginator
      * Configure -> Transform.
      *
      * @param  Cursor|int[]|string[] $cursor
-     * @return Query
+     * @return CakeQuery
      */
     public function build($cursor = [])
     {
@@ -81,7 +82,7 @@ class Paginator extends BasePaginator
 
     /**
      * @param  SelectOrUnionAll $selectOrUnionAll
-     * @return Query
+     * @return CakeQuery
      */
     protected function compileSelectOrUnionAll(SelectOrUnionAll $selectOrUnionAll)
     {
@@ -101,9 +102,8 @@ class Paginator extends BasePaginator
     }
 
     /**
-     * @param  Query  $builder
      * @param  Select $select
-     * @return Query
+     * @return CakeQuery
      */
     protected function compileSelect(Select $select)
     {
@@ -113,6 +113,8 @@ class Paginator extends BasePaginator
 
         /** @var Table $repository */
         $repository = $this->builder->getRepository();
+
+        /** @var \Cake\ORM\Query $builder */
         $builder = $repository->query()
             ->where($this->builder->clause('where'))
             ->modifier($this->builder->clause('modifier'))
@@ -123,12 +125,13 @@ class Paginator extends BasePaginator
             ->compileWhere($builder, $select)
             ->compileOrderBy($builder, $select)
             ->compileLimit($builder, $select);
+
         return $builder;
     }
 
     /**
-     * @param  Query  $builder
-     * @param  Select $select
+     * @param  CakeQuery $builder
+     * @param  Select    $select
      * @return $this
      */
     protected function compileWhere($builder, Select $select)
@@ -142,7 +145,7 @@ class Paginator extends BasePaginator
     }
 
     /**
-     * @param  ConditionGroup     $group
+     * @param  ConditionGroup            $group
      * @return \Generator<string,string>
      */
     protected function compileWhereGroup(ConditionGroup $group)
@@ -156,8 +159,8 @@ class Paginator extends BasePaginator
     }
 
     /**
-     * @param  Query  $builder
-     * @param  Select $select
+     * @param  CakeQuery $builder
+     * @param  Select    $select
      * @return $this
      */
     protected function compileOrderBy($builder, Select $select)
@@ -169,8 +172,8 @@ class Paginator extends BasePaginator
     }
 
     /**
-     * @param  Query  $builder
-     * @param  Select $select
+     * @param  CakeQuery $builder
+     * @param  Select    $select
      * @return $this
      */
     protected function compileLimit($builder, Select $select)

--- a/tests/TestCase/Database/SqliteCompilerTest.php
+++ b/tests/TestCase/Database/SqliteCompilerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Lampager\Cake\Test\TestCase\Database;
+
+use Cake\Datasource\ConnectionManager;
+use Cake\ORM\TableRegistry;
+use Lampager\Cake\Test\TestCase\TestCase;
+
+class SqliteCompilerTest extends TestCase
+{
+    public $fixtures = [
+        'plugin.Lampager\\Cake.Posts',
+    ];
+
+    public function setUp()
+    {
+        $config = ConnectionManager::getConfig('test');
+        $this->skipIf(strpos($config['driver'], 'Sqlite') === false, 'Not using Sqlite');
+    }
+
+    public function testSelect()
+    {
+        $posts = TableRegistry::getTableLocator()->get('Posts');
+
+        $expected = '
+            SELECT
+                Posts.* AS "Posts__*"
+            FROM
+                posts Posts
+            ORDER BY
+                modified ASC
+        ';
+
+        $actual = $posts->find()
+            ->select(['*'])
+            ->orderAsc('modified')
+            ->sql();
+
+        $this->assertSqlEquals($expected, $actual);
+    }
+
+    public function testUnion()
+    {
+        $posts = TableRegistry::getTableLocator()->get('Posts');
+
+        $expected = '
+            SELECT
+                *
+            FROM
+                (
+                    SELECT
+                        Posts.* AS "Posts__*"
+                    FROM
+                        posts Posts
+                    ORDER BY
+                        modified ASC
+                )
+            UNION ALL
+            SELECT
+                *
+            FROM
+                (
+                    DATETIME(\'now\')
+                )
+        ';
+
+        $actual = $posts->find()
+            ->select(['*'])
+            ->orderAsc('modified')
+            ->unionAll($posts->query()->func()->now())
+            ->sql();
+
+        $this->assertSqlEquals($expected, $actual);
+    }
+}

--- a/tests/TestCase/Datasource/PaginatorTest.php
+++ b/tests/TestCase/Datasource/PaginatorTest.php
@@ -23,7 +23,7 @@ class PaginatorTest extends TestCase
      * @dataProvider valueProvider
      * @dataProvider queryExpressionProvider
      */
-    public function testPaginate(callable $factory, PaginationResult $expected)
+    public function testPaginateTable(callable $factory, PaginationResult $expected)
     {
         $controller = new Controller();
         $controller->loadComponent('Paginator');
@@ -36,6 +36,27 @@ class PaginatorTest extends TestCase
         $options = $factory($posts);
 
         $this->assertJsonEquals($expected, $controller->paginate('Posts', $options));
+    }
+
+    /**
+     * @param        callable         $factory
+     * @param        PaginationResult $expected
+     * @dataProvider valueProvider
+     * @dataProvider queryExpressionProvider
+     */
+    public function testPaginateQuery(callable $factory, PaginationResult $expected)
+    {
+        $controller = new Controller();
+        $controller->loadComponent('Paginator');
+        $controller->Paginator->setPaginator(new Paginator());
+
+        /** @var Table $posts */
+        $posts = $controller->loadModel('Posts');
+
+        /** @var mixed[] $options */
+        $options = $factory($posts);
+
+        $this->assertJsonEquals($expected, $controller->paginate($posts->find('all'), $options));
     }
 
     public function valueProvider()

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1,0 +1,664 @@
+<?php
+
+namespace Lampager\Cake\Test\TestCase\ORM;
+
+use Cake\Database\Expression\OrderClauseExpression;
+use Cake\I18n\Time;
+use Cake\ORM\Entity;
+use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
+use Lampager\Cake\Model\Behavior\LampagerBehavior;
+use Lampager\Cake\ORM\Query;
+use Lampager\Cake\PaginationResult;
+use Lampager\Cake\Paginator;
+use Lampager\Cake\Test\TestCase\TestCase;
+use Lampager\Contracts\Exceptions\LampagerException;
+use Lampager\Exceptions\Query\BadKeywordException;
+use Lampager\Exceptions\Query\InsufficientConstraintsException;
+use Lampager\Exceptions\Query\LimitParameterException;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class QueryTest extends TestCase
+{
+    public $fixtures = [
+        'plugin.Lampager\\Cake.Posts',
+    ];
+
+    /**
+     * @param        callable         $factory
+     * @param        PaginationResult $expected
+     * @dataProvider orderProvider
+     */
+    public function testOrder(callable $factory, PaginationResult $expected)
+    {
+        /** @var LampagerBehavior&Table $posts */
+        $posts = TableRegistry::getTableLocator()->get('Posts');
+        $posts->addBehavior(LampagerBehavior::class);
+
+        /** @var Query $query */
+        $query = $factory($posts);
+        $this->assertJsonEquals($expected, $query->all());
+    }
+
+    /**
+     * @param        callable         $factory
+     * @param        PaginationResult $expected
+     * @dataProvider orderProvider
+     */
+    public function testOrderClear(callable $factory)
+    {
+        $this->expectException(LampagerException::class);
+        $this->expectExceptionMessage('At least one order constraint required');
+
+        /** @var LampagerBehavior&Table $posts */
+        $posts = TableRegistry::getTableLocator()->get('Posts');
+        $posts->addBehavior(LampagerBehavior::class);
+
+        /** @var Query $query */
+        $query = $factory($posts);
+        $query->order([], true);
+        $query->all();
+    }
+
+    public function testOrderIllegal()
+    {
+        $this->expectException(BadKeywordException::class);
+        $this->expectExceptionMessage('OrderClauseExpression does not have direction');
+
+        /** @var MockObject&OrderClauseExpression */
+        $expression = $this->getMockBuilder(OrderClauseExpression::class)->disableOriginalConstructor()->getMock();
+        $expression->method('sql')->willReturn('modified');
+
+        /** @var LampagerBehavior&Table $posts */
+        $posts = TableRegistry::getTableLocator()->get('Posts');
+        $posts->addBehavior(LampagerBehavior::class);
+        $posts->lampager()
+            ->order([$expression])
+            ->all();
+    }
+
+    public function testOrderQueryExpression()
+    {
+        /** @var LampagerBehavior&Table $posts */
+        $posts = TableRegistry::getTableLocator()->get('Posts');
+        $posts->addBehavior(LampagerBehavior::class);
+
+        $expected = new PaginationResult(
+            [
+                new Entity([
+                    'id' => 1,
+                    'modified' => new Time('2017-01-01 10:00:00'),
+                ]),
+            ],
+            [
+                'hasPrevious' => null,
+                'previousCursor' => null,
+                'hasNext' => true,
+                'nextCursor' => [
+                    'id' => 3,
+                    'modified' => new Time('2017-01-01 10:00:00'),
+                ],
+            ]
+        );
+
+        $actual = $posts->lampager()
+            ->order([$posts->query()->newExpr(['modified'])])
+            ->order([$posts->query()->newExpr(['id'])])
+            ->limit(1)
+            ->all();
+
+        $this->assertJsonEquals($expected, $actual);
+    }
+
+    public function testLimitQueryExpression()
+    {
+        /** @var LampagerBehavior&Table $posts */
+        $posts = TableRegistry::getTableLocator()->get('Posts');
+        $posts->addBehavior(LampagerBehavior::class);
+
+        $expected = new PaginationResult(
+            [
+                new Entity([
+                    'id' => 1,
+                    'modified' => new Time('2017-01-01 10:00:00'),
+                ]),
+            ],
+            [
+                'hasPrevious' => null,
+                'previousCursor' => null,
+                'hasNext' => true,
+                'nextCursor' => [
+                    'id' => 3,
+                    'modified' => new Time('2017-01-01 10:00:00'),
+                ],
+            ]
+        );
+
+        $actual = $posts->lampager()
+            ->orderAsc('modified')
+            ->orderAsc('id')
+            ->limit($posts->query()->newExpr(['1']))
+            ->all();
+
+        $this->assertJsonEquals($expected, $actual);
+    }
+
+    public function testLimitIllegalQueryExpression()
+    {
+        $this->expectException(LimitParameterException::class);
+        $this->expectExceptionMessage('Limit must be positive integer');
+
+        /** @var LampagerBehavior&Table $posts */
+        $posts = TableRegistry::getTableLocator()->get('Posts');
+        $posts->addBehavior(LampagerBehavior::class);
+        $posts->lampager()
+            ->orderAsc('modified')
+            ->orderAsc('id')
+            ->limit($posts->query()->newExpr(['1 + 1']))
+            ->all();
+    }
+
+    public function testWhere()
+    {
+        /** @var LampagerBehavior&Table $posts */
+        $posts = TableRegistry::getTableLocator()->get('Posts');
+        $posts->addBehavior(LampagerBehavior::class);
+
+        $expected = new PaginationResult(
+            [
+                new Entity([
+                    'id' => 3,
+                    'modified' => new Time('2017-01-01 10:00:00'),
+                ]),
+            ],
+            [
+                'hasPrevious' => null,
+                'previousCursor' => null,
+                'hasNext' => true,
+                'nextCursor' => [
+                    'id' => 5,
+                    'modified' => new Time('2017-01-01 10:00:00'),
+                ],
+            ]
+        );
+
+        $actual = $posts->lampager()
+            ->where(['id >' => 1])
+            ->orderAsc('modified')
+            ->orderAsc('id')
+            ->limit(1)
+            ->all();
+
+        $this->assertJsonEquals($expected, $actual);
+    }
+
+    public function testGroup()
+    {
+        $this->expectException(InsufficientConstraintsException::class);
+        $this->expectExceptionMessage('group()/union() are not supported');
+
+        /** @var LampagerBehavior&Table $posts */
+        $posts = TableRegistry::getTableLocator()->get('Posts');
+        $posts->addBehavior(LampagerBehavior::class);
+        $posts->lampager()
+            ->orderAsc('modified')
+            ->orderAsc('id')
+            ->group('modified')
+            ->all();
+    }
+
+    public function testUnion()
+    {
+        $this->expectException(InsufficientConstraintsException::class);
+        $this->expectExceptionMessage('group()/union() are not supported');
+
+        /** @var LampagerBehavior&Table $posts */
+        $posts = TableRegistry::getTableLocator()->get('Posts');
+        $posts->addBehavior(LampagerBehavior::class);
+        $posts->lampager()
+            ->orderAsc('modified')
+            ->orderAsc('id')
+            ->union($posts->query()->select())
+            ->all();
+    }
+
+    public function testCall()
+    {
+        /** @var LampagerBehavior&Table $posts */
+        $posts = TableRegistry::getTableLocator()->get('Posts');
+        $posts->addBehavior(LampagerBehavior::class);
+
+        $actual = $posts->lampager()
+            ->orderAsc('id')
+            ->take();
+
+        $expected = [
+            new Entity([
+                'id' => 1,
+                'modified' => new Time('2017-01-01 10:00:00'),
+            ]),
+        ];
+
+        $this->assertJsonEquals($expected, $actual);
+    }
+
+    public function testDebugInfo()
+    {
+        /** @var LampagerBehavior&Table $posts */
+        $posts = TableRegistry::getTableLocator()->get('Posts');
+        $posts->addBehavior(LampagerBehavior::class);
+
+        $actual = $posts->lampager()
+            ->orderAsc('modified')
+            ->orderAsc('id')
+            ->limit(3)
+            ->__debugInfo();
+
+        $this->assertSame('This is a Lampager Query object to get the paginated results.', $actual['(help)']);
+        $this->assertInstanceOf(Paginator::class, $actual['paginator']);
+        $this->assertTextStartsWith('SELECT ', $actual['sql']);
+        $this->assertSame($posts, $actual['repository']);
+
+        $this->assertArrayHasKey('params', $actual);
+        $this->assertArrayHasKey('defaultTypes', $actual);
+        $this->assertArrayHasKey('decorators', $actual);
+        $this->assertArrayHasKey('executed', $actual);
+        $this->assertArrayHasKey('hydrate', $actual);
+        $this->assertArrayHasKey('buffered', $actual);
+        $this->assertArrayHasKey('formatters', $actual);
+        $this->assertArrayHasKey('mapReducers', $actual);
+        $this->assertArrayHasKey('contain', $actual);
+        $this->assertArrayHasKey('matching', $actual);
+        $this->assertArrayHasKey('extraOptions', $actual);
+    }
+
+    public function testDebugInfoIncomplete()
+    {
+        /** @var LampagerBehavior&Table $posts */
+        $posts = TableRegistry::getTableLocator()->get('Posts');
+        $posts->addBehavior(LampagerBehavior::class);
+
+        $actual = $posts->lampager()
+            ->limit(3)
+            ->__debugInfo();
+
+        $this->assertSame('This is a Lampager Query object to get the paginated results.', $actual['(help)']);
+        $this->assertInstanceOf(Paginator::class, $actual['paginator']);
+        $this->assertSame('SQL could not be generated for this query as it is incomplete: At least one order constraint required', $actual['sql']);
+        $this->assertSame($posts, $actual['repository']);
+
+        $this->assertArrayHasKey('params', $actual);
+        $this->assertArrayHasKey('defaultTypes', $actual);
+        $this->assertArrayHasKey('decorators', $actual);
+        $this->assertArrayHasKey('executed', $actual);
+        $this->assertArrayHasKey('hydrate', $actual);
+        $this->assertArrayHasKey('buffered', $actual);
+        $this->assertArrayHasKey('formatters', $actual);
+        $this->assertArrayHasKey('mapReducers', $actual);
+        $this->assertArrayHasKey('contain', $actual);
+        $this->assertArrayHasKey('matching', $actual);
+        $this->assertArrayHasKey('extraOptions', $actual);
+    }
+
+    /**
+     * @param        callable      $factory
+     * @param        int           $expected
+     * @dataProvider countProvider
+     */
+    public function testCount(callable $factory, $expected)
+    {
+        /** @var LampagerBehavior&Table $posts */
+        $posts = TableRegistry::getTableLocator()->get('Posts');
+        $posts->addBehavior(LampagerBehavior::class);
+
+        $this->assertSame($expected, $factory($posts));
+    }
+
+    public function orderProvider()
+    {
+        yield 'Ascending and ascending' => [
+            function (Table $posts) {
+                /** @var LampagerBehavior&Table $posts */
+                return $posts->lampager()
+                    ->forward()
+                    ->seekable()
+                    ->limit(3)
+                    ->order([
+                        'modified' => 'asc',
+                        'id' => 'asc',
+                    ]);
+            },
+            new PaginationResult(
+                [
+                    new Entity([
+                        'id' => 1,
+                        'modified' => new Time('2017-01-01 10:00:00'),
+                    ]),
+                    new Entity([
+                        'id' => 3,
+                        'modified' => new Time('2017-01-01 10:00:00'),
+                    ]),
+                    new Entity([
+                        'id' => 5,
+                        'modified' => new Time('2017-01-01 10:00:00'),
+                    ]),
+                ],
+                [
+                    'hasPrevious' => null,
+                    'previousCursor' => null,
+                    'hasNext' => true,
+                    'nextCursor' => [
+                        'id' => 2,
+                        'modified' => new Time('2017-01-01 11:00:00'),
+                    ],
+                ]
+            ),
+        ];
+
+        yield 'Descending and descending' => [
+            function (Table $posts) {
+                /** @var LampagerBehavior&Table $posts */
+                return $posts->lampager()
+                    ->forward()
+                    ->seekable()
+                    ->limit(3)
+                    ->order([
+                        'modified' => 'desc',
+                        'id' => 'desc',
+                    ]);
+            },
+            new PaginationResult(
+                [
+                    new Entity([
+                        'id' => 4,
+                        'modified' => new Time('2017-01-01 11:00:00'),
+                    ]),
+                    new Entity([
+                        'id' => 2,
+                        'modified' => new Time('2017-01-01 11:00:00'),
+                    ]),
+                    new Entity([
+                        'id' => 5,
+                        'modified' => new Time('2017-01-01 10:00:00'),
+                    ]),
+                ],
+                [
+                    'hasPrevious' => null,
+                    'previousCursor' => null,
+                    'hasNext' => true,
+                    'nextCursor' => [
+                        'id' => 3,
+                        'modified' => new Time('2017-01-01 10:00:00'),
+                    ],
+                ]
+            ),
+        ];
+    }
+
+    public function countProvider()
+    {
+        yield 'Ascending forward start inclusive' => [
+            function (Table $posts) {
+                /** @var LampagerBehavior&Table $posts */
+                return $posts->lampager()
+                    ->forward()
+                    ->seekable()
+                    ->limit(3)
+                    ->orderAsc('modified')
+                    ->orderAsc('id')
+                    ->count();
+            },
+            3,
+        ];
+
+        yield 'Ascending forward start exclusive' => [
+            function (Table $posts) {
+                /** @var LampagerBehavior&Table $posts */
+                return $posts->lampager()
+                    ->forward()
+                    ->seekable()
+                    ->exclusive()
+                    ->limit(3)
+                    ->orderAsc('modified')
+                    ->orderAsc('id')
+                    ->count();
+            },
+            3,
+        ];
+
+        yield 'Ascending forward inclusive' => [
+            function (Table $posts) {
+                /** @var LampagerBehavior&Table $posts */
+                return $posts->lampager()
+                    ->forward()
+                    ->seekable()
+                    ->limit(3)
+                    ->orderAsc('modified')
+                    ->orderAsc('id')
+                    ->cursor([
+                        'id' => 3,
+                        'modified' => new Time('2017-01-01 10:00:00'),
+                    ])
+                    ->count();
+            },
+            3,
+        ];
+
+        yield 'Ascending forward exclusive' => [
+            function (Table $posts) {
+                /** @var LampagerBehavior&Table $posts */
+                return $posts->lampager()
+                    ->forward()
+                    ->seekable()
+                    ->exclusive()
+                    ->limit(3)
+                    ->orderAsc('modified')
+                    ->orderAsc('id')
+                    ->cursor([
+                        'id' => 3,
+                        'modified' => new Time('2017-01-01 10:00:00'),
+                    ])
+                    ->count();
+            },
+            3,
+        ];
+
+        yield 'Ascending backward start inclusive' => [
+            function (Table $posts) {
+                /** @var LampagerBehavior&Table $posts */
+                return $posts->lampager()
+                    ->backward()
+                    ->seekable()
+                    ->limit(3)
+                    ->orderAsc('modified')
+                    ->orderAsc('id')
+                    ->count();
+            },
+            3,
+        ];
+
+        yield 'Ascending backward start exclusive' => [
+            function (Table $posts) {
+                /** @var LampagerBehavior&Table $posts */
+                return $posts->lampager()
+                    ->backward()
+                    ->seekable()
+                    ->exclusive()
+                    ->limit(3)
+                    ->orderAsc('modified')
+                    ->orderAsc('id')
+                    ->count();
+            },
+            3,
+        ];
+
+        yield 'Ascending backward inclusive' => [
+            function (Table $posts) {
+                /** @var LampagerBehavior&Table $posts */
+                return $posts->lampager()
+                    ->backward()
+                    ->seekable()
+                    ->limit(3)
+                    ->orderAsc('modified')
+                    ->orderAsc('id')
+                    ->cursor([
+                        'id' => 3,
+                        'modified' => new Time('2017-01-01 10:00:00'),
+                    ])
+                    ->count();
+            },
+            2,
+        ];
+
+        yield 'Ascending backward exclusive' => [
+            function (Table $posts) {
+                /** @var LampagerBehavior&Table $posts */
+                return $posts->lampager()
+                    ->backward()
+                    ->seekable()
+                    ->exclusive()
+                    ->limit(3)
+                    ->orderAsc('modified')
+                    ->orderAsc('id')
+                    ->cursor([
+                        'id' => 3,
+                        'modified' => new Time('2017-01-01 10:00:00'),
+                    ])
+                    ->count();
+            },
+            1,
+        ];
+
+        yield 'Descending forward start inclusive' => [
+            function (Table $posts) {
+                /** @var LampagerBehavior&Table $posts */
+                return $posts->lampager()
+                    ->forward()
+                    ->seekable()
+                    ->limit(3)
+                    ->orderDesc('modified')
+                    ->orderDesc('id')
+                    ->count();
+            },
+            3,
+        ];
+
+        yield 'Descending forward start exclusive' => [
+            function (Table $posts) {
+                /** @var LampagerBehavior&Table $posts */
+                return $posts->lampager()
+                    ->forward()
+                    ->seekable()
+                    ->exclusive()
+                    ->limit(3)
+                    ->orderDesc('modified')
+                    ->orderDesc('id')
+                    ->count();
+            },
+            3,
+        ];
+
+        yield 'Descending forward inclusive' => [
+            function (Table $posts) {
+                /** @var LampagerBehavior&Table $posts */
+                return $posts->lampager()
+                    ->forward()
+                    ->seekable()
+                    ->limit(3)
+                    ->orderDesc('modified')
+                    ->orderDesc('id')
+                    ->cursor([
+                        'id' => 3,
+                        'modified' => new Time('2017-01-01 10:00:00'),
+                    ])
+                    ->count();
+            },
+            2,
+        ];
+
+        yield 'Descending forward exclusive' => [
+            function (Table $posts) {
+                /** @var LampagerBehavior&Table $posts */
+                return $posts->lampager()
+                    ->forward()
+                    ->seekable()
+                    ->exclusive()
+                    ->limit(3)
+                    ->orderDesc('modified')
+                    ->orderDesc('id')
+                    ->cursor([
+                        'id' => 3,
+                        'modified' => new Time('2017-01-01 10:00:00'),
+                    ])
+                    ->count();
+            },
+            1,
+        ];
+
+        yield 'Descending backward start inclusive' => [
+            function (Table $posts) {
+                /** @var LampagerBehavior&Table $posts */
+                return $posts->lampager()
+                    ->backward()
+                    ->seekable()
+                    ->limit(3)
+                    ->orderDesc('modified')
+                    ->orderDesc('id')
+                    ->count();
+            },
+            3,
+        ];
+
+        yield 'Descending backward start exclusive' => [
+            function (Table $posts) {
+                /** @var LampagerBehavior&Table $posts */
+                return $posts->lampager()
+                    ->backward()
+                    ->seekable()
+                    ->exclusive()
+                    ->limit(3)
+                    ->orderDesc('modified')
+                    ->orderDesc('id')
+                    ->count();
+            },
+            3,
+        ];
+
+        yield 'Descending backward inclusive' => [
+            function (Table $posts) {
+                /** @var LampagerBehavior&Table $posts */
+                return $posts->lampager()
+                    ->backward()
+                    ->seekable()
+                    ->limit(3)
+                    ->orderDesc('modified')
+                    ->orderDesc('id')
+                    ->cursor([
+                        'id' => 3,
+                        'modified' => new Time('2017-01-01 10:00:00'),
+                    ])
+                    ->count();
+            },
+            3,
+        ];
+
+        yield 'Descending backward exclusive' => [
+            function (Table $posts) {
+                /** @var LampagerBehavior&Table $posts */
+                return $posts->lampager()
+                    ->backward()
+                    ->seekable()
+                    ->exclusive()
+                    ->limit(3)
+                    ->orderDesc('modified')
+                    ->orderDesc('id')
+                    ->cursor([
+                        'id' => 3,
+                        'modified' => new Time('2017-01-01 10:00:00'),
+                    ])
+                    ->count();
+            },
+            3,
+        ];
+    }
+}

--- a/tests/TestCase/PaginatorTest.php
+++ b/tests/TestCase/PaginatorTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Lampager\Cake\Test\TestCase;
+
+use Lampager\Cake\ORM\Query;
+use Lampager\Cake\Paginator;
+use Lampager\Query\Order;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class PaginatorTest extends TestCase
+{
+    public function testDebugInfo()
+    {
+        /** @var MockObject&Query */
+        $builder = $this->getMockBuilder(Query::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $paginator = (new Paginator($builder))
+            ->orderBy('modified')
+            ->orderBy('id')
+            ->limit(3)
+            ->forward()
+            ->inclusive()
+            ->seekable();
+
+        $actual = $paginator->__debugInfo();
+        $this->assertEquals([
+            'query' => [
+                'orders' => [
+                    new Order('modified', 'asc'),
+                    new Order('id', 'asc'),
+                ],
+                'limit' => 3,
+                'forward' => true,
+                'inclusive' => true,
+                'seekable' => true,
+            ],
+        ], $actual);
+    }
+}

--- a/tests/TestCase/TestCase.php
+++ b/tests/TestCase/TestCase.php
@@ -3,6 +3,7 @@
 namespace Lampager\Cake\Test\TestCase;
 
 use Cake\TestSuite\TestCase as BaseTestCase;
+use NilPortugues\Sql\QueryFormatter\Formatter;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -19,5 +20,19 @@ abstract class TestCase extends BaseTestCase
     public function assertJsonEquals($expected, $actual, $message = '')
     {
         $this->assertJsonStringEqualsJsonString(json_encode($expected), json_encode($actual), $message);
+    }
+
+    /**
+     * Asserts that two given SQL query statements are equal.
+     *
+     * @param  string $expected
+     * @param  string $actual
+     * @param  string $message
+     * @return void
+     */
+    public function assertSqlEquals($expected, $actual, $message = '')
+    {
+        $formatter = new Formatter();
+        $this->assertSame($formatter->format($expected), $formatter->format($actual), $message);
     }
 }


### PR DESCRIPTION
- Install `nilportugues/sql-query-formatter`
- `count()` now returns the number of the result set considering pagination
- `BadKeywordException` is thrown if `OrderClauseExpressio` does not have direction
- `LimitParameterException` is thrown if `QueryExpression` passed to `limit()` is not a positive integer
- `Query` object can now dump its information even when its state is incomplete
- Fix a bug where `Paginator` dropped queries other than `order()` and `limit()`
- `InsufficientConstraintsException` is thrown if `group()` or `union()` is specified
- The coverage now reaches 100%!

![image](https://user-images.githubusercontent.com/6535425/71676516-bebab080-2dc3-11ea-8ff3-f94481f75c23.png)
