### PR TITLE
Support CakePHP 4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.6
   - 7.2
   - 7.3
   - 7.4

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Rapid pagination without using OFFSET
 
 ## Requirements
 
-- PHP: ^5.6 || ^7.0
-- CakePHP: ^3.6
+- PHP: ^7.2
+- CakePHP: ^4.0
 - [lampager/lampager][]: ^0.4
 
 Note: [lampager/lampager-cakephp2][]

--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ Rapid pagination without using OFFSET
 - CakePHP: ^4.0
 - [lampager/lampager][]: ^0.4
 
-Note: [lampager/lampager-cakephp2][]
-for CakePHP 2.x is available!
+### Note
+
+- For CakePHP 2.x, use [lampager/lampager-cakephp2][].
+- For CakePHP 3.x, use [v1.x][lampager/lampager (v1.x)].
+- For CakePHP 4.x, use v2.x (this version).
 
 ## Installing
 
@@ -415,6 +418,7 @@ return [
 ```
 
 [lampager/lampager]:          https://github.com/lampager/lampager
+[lampager/lampager (v1.x)]:   https://github.com/lampager/lampager-cakephp/tree/v1.x
 [lampager/lampager-cakephp2]: https://github.com/lampager/lampager-cakephp2
 [Pagination]:                 https://book.cakephp.org/3/en/controllers/components/pagination.html
 [Working with Result Sets]:   https://book.cakephp.org/3/en/orm/retrieving-data-and-resultsets.html#working-with-result-sets

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ Rapid pagination without using OFFSET
 ### Note
 
 - For CakePHP 2.x, use [lampager/lampager-cakephp2][].
-- For CakePHP 3.x, use [v1.x][lampager/lampager (v1.x)].
-- For CakePHP 4.x, use v2.x (this version).
+- For CakePHP 3.x, use [lampager/lampager-cakephp (v1.x)][].
+- For CakePHP 4.x, use lampager/lampager-cakephp v2.x (this version).
 
 ## Installing
 
 ```bash
-composer require lampager/lampager-cakephp
+composer require lampager/lampager-cakephp:^2.0
 ```
 
 For SQLite users, see [SQLite](#sqlite) to configure.
@@ -417,8 +417,8 @@ return [
 ];
 ```
 
-[lampager/lampager]:          https://github.com/lampager/lampager
-[lampager/lampager (v1.x)]:   https://github.com/lampager/lampager-cakephp/tree/v1.x
-[lampager/lampager-cakephp2]: https://github.com/lampager/lampager-cakephp2
-[Pagination]:                 https://book.cakephp.org/3/en/controllers/components/pagination.html
-[Working with Result Sets]:   https://book.cakephp.org/3/en/orm/retrieving-data-and-resultsets.html#working-with-result-sets
+[lampager/lampager]:                https://github.com/lampager/lampager
+[lampager/lampager-cakephp (v1.x)]: https://github.com/lampager/lampager-cakephp/tree/v1.x
+[lampager/lampager-cakephp2]:       https://github.com/lampager/lampager-cakephp2
+[Pagination]:                       https://book.cakephp.org/3/en/controllers/components/pagination.html
+[Working with Result Sets]:         https://book.cakephp.org/3/en/orm/retrieving-data-and-resultsets.html#working-with-result-sets

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Rapid pagination without using OFFSET
 ### Note
 
 - For CakePHP 2.x, use [lampager/lampager-cakephp2][].
-- For CakePHP 3.x, use [lampager/lampager-cakephp (v1.x)][].
+- For CakePHP 3.x, use [lampager/lampager-cakephp v1.x][].
 - For CakePHP 4.x, use lampager/lampager-cakephp v2.x (this version).
 
 ## Installing
@@ -417,8 +417,8 @@ return [
 ];
 ```
 
-[lampager/lampager]:                https://github.com/lampager/lampager
-[lampager/lampager-cakephp (v1.x)]: https://github.com/lampager/lampager-cakephp/tree/v1.x
-[lampager/lampager-cakephp2]:       https://github.com/lampager/lampager-cakephp2
-[Pagination]:                       https://book.cakephp.org/3/en/controllers/components/pagination.html
-[Working with Result Sets]:         https://book.cakephp.org/3/en/orm/retrieving-data-and-resultsets.html#working-with-result-sets
+[lampager/lampager]:              https://github.com/lampager/lampager
+[lampager/lampager-cakephp v1.x]: https://github.com/lampager/lampager-cakephp/tree/v1.x
+[lampager/lampager-cakephp2]:     https://github.com/lampager/lampager-cakephp2
+[Pagination]:                     https://book.cakephp.org/3/en/controllers/components/pagination.html
+[Working with Result Sets]:       https://book.cakephp.org/3/en/orm/retrieving-data-and-resultsets.html#working-with-result-sets

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ use Lampager\Cake\Datasource\Paginator;
 
 class AppController extends Controller
 {
-    public function initialize()
+    public function initialize(): void
     {
         parent::initialize();
 
@@ -99,7 +99,7 @@ use Lampager\Cake\Model\Behavior\LampagerBehavior;
 
 class AppTable extends Table
 {
-    public function initialize(array $config)
+    public function initialize(array $config): void
     {
         parent::initialize($config);
 
@@ -297,7 +297,7 @@ class PostsController extends AppController
     /**
      * This method shows how to pass options by a query and array.
      */
-    public function query()
+    public function query(): void
     {
         // Get cursor parameters
         $previous = json_decode($this->request->getQuery('previous_cursor'), true);
@@ -325,7 +325,7 @@ class PostsController extends AppController
     /**
      * This method shows how to pass options from an array.
      */
-    public function options()
+    public function options(): void
     {
         // Get cursor parameters
         $previous = json_decode($this->request->getQuery('previous_cursor'), true);
@@ -420,5 +420,5 @@ return [
 [lampager/lampager]:              https://github.com/lampager/lampager
 [lampager/lampager-cakephp v1.x]: https://github.com/lampager/lampager-cakephp/tree/v1.x
 [lampager/lampager-cakephp2]:     https://github.com/lampager/lampager-cakephp2
-[Pagination]:                     https://book.cakephp.org/3/en/controllers/components/pagination.html
-[Working with Result Sets]:       https://book.cakephp.org/3/en/orm/retrieving-data-and-resultsets.html#working-with-result-sets
+[Pagination]:                     https://book.cakephp.org/4/en/controllers/components/pagination.html
+[Working with Result Sets]:       https://book.cakephp.org/4/en/orm/retrieving-data-and-resultsets.html#working-with-result-sets

--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
         }
     },
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.2",
         "lampager/lampager": "^0.4"
     },
     "require-dev": {
-        "cakephp/cakephp": "^3.6",
-        "phpunit/phpunit": "^5.7 || ^6.0",
+        "cakephp/cakephp": "^4.0",
+        "phpunit/phpunit": "^8.0",
         "php-coveralls/php-coveralls": "^2.2",
         "nilportugues/sql-query-formatter": "^1.2"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,6 @@
 <phpunit colors="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="tests/bootstrap.php">
     <testsuites>
         <testsuite name="Lampager CakePHP Test Suite">

--- a/src/ArrayProcessor.php
+++ b/src/ArrayProcessor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Lampager\Cake;
 
 use Cake\ORM\Entity;
@@ -25,7 +27,7 @@ class ArrayProcessor extends BaseArrayProcessor
      * @param  string $alias  Current model alias
      * @return string Unaliased column where applicable
      */
-    protected function removeAlias($column, $alias)
+    protected function removeAlias(string $column, string $alias): string
     {
         if (strpos($column, "{$alias}.") !== 0) {
             return $column;

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -1,8 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Lampager\Cake\Database\Driver;
 
 use Cake\Database\Driver\Sqlite as BaseSqlite;
+use Cake\Database\QueryCompiler;
 use Lampager\Cake\Database\SqliteCompiler;
 
 class Sqlite extends BaseSqlite
@@ -10,7 +13,7 @@ class Sqlite extends BaseSqlite
     /**
      * {@inheritdoc}
      */
-    public function newCompiler()
+    public function newCompiler(): QueryCompiler
     {
         return new SqliteCompiler();
     }

--- a/src/Database/SqliteCompiler.php
+++ b/src/Database/SqliteCompiler.php
@@ -1,15 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Lampager\Cake\Database;
 
+use Cake\Database\Query;
 use Cake\Database\SqliteCompiler as BaseSqliteCompiler;
+use Cake\Database\ValueBinder;
 
 class SqliteCompiler extends BaseSqliteCompiler
 {
     /**
      * {@inheritdoc}
      */
-    protected function _buildSelectPart($parts, $query, $generator)
+    protected function _buildSelectPart(array $parts, Query $query, ValueBinder $generator): string
     {
         if (!$query->clause('union')) {
             return parent::_buildSelectPart($parts, $query, $generator);
@@ -21,7 +25,7 @@ class SqliteCompiler extends BaseSqliteCompiler
     /**
      * {@inheritdoc}
      */
-    protected function _buildUnionPart($parts, $query, $generator)
+    protected function _buildUnionPart(array $parts, Query $query, ValueBinder $generator): string
     {
         $parts = array_map(function ($p) use ($generator) {
             $p['query'] = $p['query']->sql($generator);

--- a/src/Datasource/Paginator.php
+++ b/src/Datasource/Paginator.php
@@ -1,9 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Lampager\Cake\Datasource;
 
 use Cake\Datasource\Paginator as CakePaginator;
 use Cake\Datasource\QueryInterface;
+use Cake\Datasource\ResultSetInterface;
 use Lampager\Cake\ORM\Query;
 use Lampager\Cake\PaginationResult;
 use Lampager\Exceptions\InvalidArgumentException;
@@ -15,7 +18,7 @@ class Paginator extends CakePaginator
      * @throws InvalidArgumentException if the \Lampager\Cake\ORM\Query is given
      * @return PaginationResult
      */
-    public function paginate($object, array $params = [], array $settings = [])
+    public function paginate(object $object, array $params = [], array $settings = []): ResultSetInterface
     {
         $query = null;
         if ($object instanceof QueryInterface) {

--- a/src/Datasource/Paginator.php
+++ b/src/Datasource/Paginator.php
@@ -7,6 +7,7 @@ namespace Lampager\Cake\Datasource;
 use Cake\Datasource\Paginator as CakePaginator;
 use Cake\Datasource\QueryInterface;
 use Cake\Datasource\ResultSetInterface;
+use Exception;
 use Lampager\Cake\ORM\Query;
 use Lampager\Cake\PaginationResult;
 use Lampager\Exceptions\InvalidArgumentException;
@@ -24,6 +25,9 @@ class Paginator extends CakePaginator
         if ($object instanceof QueryInterface) {
             $query = $object;
             $object = $query->getRepository();
+            if ($object === null) {
+                throw new Exception('No repository set for query.');
+            }
         }
 
         if ($query instanceof Query) {

--- a/src/Model/Behavior/LampagerBehavior.php
+++ b/src/Model/Behavior/LampagerBehavior.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Lampager\Cake\Model\Behavior;
 
 use Cake\ORM\Behavior;
@@ -7,10 +9,7 @@ use Lampager\Cake\ORM\Query;
 
 class LampagerBehavior extends Behavior
 {
-    /**
-     * @return Query
-     */
-    public function lampager()
+    public function lampager(): Query
     {
         $query = new Query($this->getTable()->getConnection(), $this->getTable());
         $query->select();

--- a/src/Model/Behavior/LampagerBehavior.php
+++ b/src/Model/Behavior/LampagerBehavior.php
@@ -14,6 +14,6 @@ class LampagerBehavior extends Behavior
         $query = new Query($this->getTable()->getConnection(), $this->getTable());
         $query->select();
 
-        return $this->getTable()->callFinder('all', $query, []);
+        return $query;
     }
 }

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -1,11 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Lampager\Cake\ORM;
 
 use Cake\Database\Expression\OrderByExpression;
 use Cake\Database\Expression\OrderClauseExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\ExpressionInterface;
+use Cake\Datasource\ResultSetInterface;
 use Cake\ORM\Query as BaseQuery;
 use Lampager\Cake\PaginationResult;
 use Lampager\Cake\Paginator;
@@ -47,10 +50,8 @@ class Query extends BaseQuery
     /**
      * Create query based on the existing query. This factory copies the internal
      * state of the given query to a new instance.
-     *
-     * @param BaseQuery $query
      */
-    public static function fromQuery($query)
+    public static function fromQuery(BaseQuery $query)
     {
         $obj = new static($query->getConnection(), $query->getRepository());
 
@@ -124,7 +125,7 @@ class Query extends BaseQuery
      * {@inheritdoc}
      * @return PaginationResult
      */
-    public function all()
+    public function all(): ResultSetInterface
     {
         return $this->_paginator->paginate($this->_cursor);
     }
@@ -132,16 +133,12 @@ class Query extends BaseQuery
     /**
      * {@inheritdoc}
      */
-    protected function _performCount()
+    protected function _performCount(): int
     {
         return $this->all()->count();
     }
 
-    /**
-     * @param  null|OrderByExpression $order
-     * @return void
-     */
-    protected function _executeOrder($order)
+    protected function _executeOrder(?OrderByExpression $order): void
     {
         $this->_paginator->clearOrderBy();
 
@@ -188,10 +185,9 @@ class Query extends BaseQuery
     }
 
     /**
-     * @param  null|int|QueryExpression $limit
-     * @return void
+     * @param null|int|QueryExpression $limit
      */
-    protected function _executeLimit($limit)
+    protected function _executeLimit($limit): void
     {
         if (is_int($limit)) {
             $this->_paginator->limit($limit);
@@ -219,7 +215,7 @@ class Query extends BaseQuery
     /**
      * {@inheritdoc}
      */
-    public function __call($method, $args)
+    public function __call(string $method, array $arguments)
     {
         static $options = [
             'forward',
@@ -232,17 +228,17 @@ class Query extends BaseQuery
         ];
 
         if (in_array($method, $options, true)) {
-            $this->_paginator->$method(...$args);
+            $this->_paginator->$method(...$arguments);
             return $this;
         }
 
-        return parent::__call($method, $args);
+        return parent::__call($method, $arguments);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function __debugInfo()
+    public function __debugInfo(): array
     {
         try {
             $info = $this->_paginator->build($this->_cursor)->__debugInfo();

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Lampager\Cake\ORM;
 
+use Cake\Database\Connection;
 use Cake\Database\Expression\OrderByExpression;
 use Cake\Database\Expression\OrderClauseExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\ExpressionInterface;
 use Cake\Datasource\ResultSetInterface;
 use Cake\ORM\Query as BaseQuery;
+use Cake\ORM\Table;
 use Lampager\Cake\PaginationResult;
 use Lampager\Cake\Paginator;
 use Lampager\Contracts\Cursor;
@@ -37,10 +39,10 @@ class Query extends BaseQuery
     /**
      * Construct query.
      *
-     * @param \Cake\Database\Connection $connection The connection object
-     * @param \Cake\ORM\Table           $table      The table this query is starting on
+     * @param Connection $connection The connection object
+     * @param Table      $table      The table this query is starting on
      */
-    public function __construct($connection, $table)
+    public function __construct(Connection $connection, Table $table)
     {
         parent::__construct($connection, $table);
 

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -167,6 +167,8 @@ class Query extends BaseQuery
 
                 /** @var string $direction */
                 $direction = $matches['direction'];
+
+                /** @var ExpressionInterface|string $field */
                 $field = $condition->getField();
 
                 if ($field instanceof ExpressionInterface) {

--- a/src/PaginationResult.php
+++ b/src/PaginationResult.php
@@ -131,9 +131,6 @@ class PaginationResult implements ResultSetInterface
         $this->result = new LampagerPaginationResult($obj['records'], $meta);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getIterator(): Iterator
     {
         /** @var Iterator|IteratorAggregate */

--- a/src/PaginationResult.php
+++ b/src/PaginationResult.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Lampager\Cake;
 
 use Cake\Collection\CollectionTrait;
@@ -7,6 +9,7 @@ use Cake\Datasource\ResultSetInterface;
 use Iterator;
 use IteratorAggregate;
 use Lampager\PaginationResult as LampagerPaginationResult;
+use Traversable;
 
 /**
  * Class PaginationResult
@@ -78,8 +81,9 @@ class PaginationResult implements ResultSetInterface
 
     /**
      * {@inheritdoc}
+     * @return Iterator
      */
-    public function unwrap()
+    public function unwrap(): Traversable
     {
         if (!$this->iterator) {
             $this->iterator = $this->getIterator();
@@ -91,7 +95,7 @@ class PaginationResult implements ResultSetInterface
     /**
      * {@inheritdoc}
      */
-    public function toArray($preserveKeys = true)
+    public function toArray(bool $preserveKeys = true): array
     {
         $array = (array)$this->result;
         $array['records'] = iterator_to_array($this->unwrap());
@@ -102,7 +106,7 @@ class PaginationResult implements ResultSetInterface
     /**
      * {@inheritdoc}
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }
@@ -128,9 +132,9 @@ class PaginationResult implements ResultSetInterface
     }
 
     /**
-     * @return Iterator
+     * {@inheritdoc}
      */
-    protected function getIterator()
+    protected function getIterator(): Iterator
     {
         /** @var Iterator|IteratorAggregate */
         $iterator = $this->result->getIterator();
@@ -145,10 +149,8 @@ class PaginationResult implements ResultSetInterface
     /**
      * Returns an array that can be used to describe the internal state of this
      * object.
-     *
-     * @return array
      */
-    public function __debugInfo()
+    public function __debugInfo(): array
     {
         return [
             '(help)' => 'This is a Lampager Pagination Result object.',

--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -1,9 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Lampager\Cake;
 
 use Cake\ORM\Query;
 use Cake\ORM\Table;
+use Generator;
 use Lampager\Concerns\HasProcessor;
 use Lampager\Contracts\Cursor;
 use Lampager\Exceptions\Query\InsufficientConstraintsException;
@@ -43,10 +46,8 @@ class Paginator extends BasePaginator
 
     /**
      * Build CakePHP Query instance from Lampager Query config.
-     *
-     * @return Query
      */
-    public function transform(LampagerQuery $query)
+    public function transform(LampagerQuery $query): Query
     {
         return $this->compileSelectOrUnionAll($query->selectOrUnionAll());
     }
@@ -54,10 +55,9 @@ class Paginator extends BasePaginator
     /**
      * Configure -> Transform.
      *
-     * @param  Cursor|int[]|string[] $cursor
-     * @return Query
+     * @param Cursor|int[]|string[] $cursor
      */
-    public function build($cursor = [])
+    public function build($cursor = []): Query
     {
         return $this->transform($this->configure($cursor));
     }
@@ -74,10 +74,7 @@ class Paginator extends BasePaginator
         return $this->process($query, $this->transform($query)->toArray());
     }
 
-    /**
-     * @return Query
-     */
-    protected function compileSelectOrUnionAll(SelectOrUnionAll $selectOrUnionAll)
+    protected function compileSelectOrUnionAll(SelectOrUnionAll $selectOrUnionAll): Query
     {
         if ($selectOrUnionAll instanceof Select) {
             return $this->compileSelect($selectOrUnionAll);
@@ -94,10 +91,7 @@ class Paginator extends BasePaginator
         // @codeCoverageIgnoreEnd
     }
 
-    /**
-     * @return Query
-     */
-    protected function compileSelect(Select $select)
+    protected function compileSelect(Select $select): Query
     {
         if ($this->builder->clause('group') || $this->builder->clause('union')) {
             throw new InsufficientConstraintsException('group()/union() are not supported');
@@ -122,10 +116,9 @@ class Paginator extends BasePaginator
     }
 
     /**
-     * @param  Query $builder
      * @return $this
      */
-    protected function compileWhere($builder, Select $select)
+    protected function compileWhere(Query $builder, Select $select)
     {
         $conditions = [];
         foreach ($select->where() as $group) {
@@ -138,7 +131,7 @@ class Paginator extends BasePaginator
     /**
      * @return \Generator<string,string>
      */
-    protected function compileWhereGroup(ConditionGroup $group)
+    protected function compileWhereGroup(ConditionGroup $group): Generator
     {
         /** @var Condition $condition */
         foreach ($group as $condition) {
@@ -149,10 +142,9 @@ class Paginator extends BasePaginator
     }
 
     /**
-     * @param  Query $builder
      * @return $this
      */
-    protected function compileOrderBy($builder, Select $select)
+    protected function compileOrderBy(Query $builder, Select $select)
     {
         foreach ($select->orders() as $i => $order) {
             $builder->order([$order->column() => $order->order()], $i === 0);
@@ -161,10 +153,9 @@ class Paginator extends BasePaginator
     }
 
     /**
-     * @param  Query $builder
      * @return $this
      */
-    protected function compileLimit($builder, Select $select)
+    protected function compileLimit(Query $builder, Select $select)
     {
         $builder->limit($select->limit()->toInteger());
         return $this;
@@ -172,10 +163,8 @@ class Paginator extends BasePaginator
 
     /**
      * Returns an array that can be used to describe the internal state of this object.
-     *
-     * @return array
      */
-    public function __debugInfo()
+    public function __debugInfo(): array
     {
         $query = $this->configure();
 

--- a/tests/Fixture/PostsFixture.php
+++ b/tests/Fixture/PostsFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Lampager\Cake\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;

--- a/tests/TestCase/Database/SqliteCompilerTest.php
+++ b/tests/TestCase/Database/SqliteCompilerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Lampager\Cake\Test\TestCase\Database;
 
 use Cake\Datasource\ConnectionManager;
@@ -12,13 +14,13 @@ class SqliteCompilerTest extends TestCase
         'plugin.Lampager\\Cake.Posts',
     ];
 
-    public function setUp()
+    public function setUp(): void
     {
         $config = ConnectionManager::getConfig('test');
         $this->skipIf(strpos($config['driver'], 'Sqlite') === false, 'Not using Sqlite');
     }
 
-    public function testSelect()
+    public function testSelect(): void
     {
         $posts = TableRegistry::getTableLocator()->get('Posts');
 
@@ -39,7 +41,7 @@ class SqliteCompilerTest extends TestCase
         $this->assertSqlEquals($expected, $actual);
     }
 
-    public function testUnion()
+    public function testUnion(): void
     {
         $posts = TableRegistry::getTableLocator()->get('Posts');
 

--- a/tests/TestCase/Datasource/PaginatorTest.php
+++ b/tests/TestCase/Datasource/PaginatorTest.php
@@ -6,15 +6,18 @@ namespace Lampager\Cake\Test\TestCase\Datasource;
 
 use Cake\Controller\Controller;
 use Cake\Database\Expression\OrderClauseExpression;
+use Cake\Datasource\QueryInterface;
 use Cake\I18n\Time;
 use Cake\ORM\Entity;
 use Cake\ORM\Table;
+use Exception;
 use Generator;
 use Lampager\Cake\Datasource\Paginator;
 use Lampager\Cake\Model\Behavior\LampagerBehavior;
 use Lampager\Cake\PaginationResult;
 use Lampager\Cake\Test\TestCase\TestCase;
 use Lampager\Exceptions\InvalidArgumentException;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class PaginatorTest extends TestCase
 {
@@ -80,6 +83,22 @@ class PaginatorTest extends TestCase
         /** @var mixed[] $options */
         $options = $factory($posts);
         $query = $posts->lampager()->applyOptions($options);
+        $controller->paginate($query);
+    }
+
+    public function testPaginateInvalidQuery(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('No repository set for query.');
+
+        $controller = new Controller();
+        $controller->loadComponent('Paginator');
+        $controller->Paginator->setPaginator(new Paginator());
+
+        /** @var MockObject&QueryInterface $query */
+        $query = $this->getMockBuilder(QueryInterface::class)->getMock();
+        $query->method('getRepository')->willReturn(null);
+
         $controller->paginate($query);
     }
 

--- a/tests/TestCase/Datasource/PaginatorTest.php
+++ b/tests/TestCase/Datasource/PaginatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Lampager\Cake\Test\TestCase\Datasource;
 
 use Cake\Controller\Controller;
@@ -7,6 +9,7 @@ use Cake\Database\Expression\OrderClauseExpression;
 use Cake\I18n\Time;
 use Cake\ORM\Entity;
 use Cake\ORM\Table;
+use Generator;
 use Lampager\Cake\Datasource\Paginator;
 use Lampager\Cake\Model\Behavior\LampagerBehavior;
 use Lampager\Cake\PaginationResult;
@@ -23,7 +26,7 @@ class PaginatorTest extends TestCase
      * @dataProvider valueProvider
      * @dataProvider queryExpressionProvider
      */
-    public function testPaginateTable(callable $factory, PaginationResult $expected)
+    public function testPaginateTable(callable $factory, PaginationResult $expected): void
     {
         $controller = new Controller();
         $controller->loadComponent('Paginator');
@@ -42,7 +45,7 @@ class PaginatorTest extends TestCase
      * @dataProvider valueProvider
      * @dataProvider queryExpressionProvider
      */
-    public function testPaginateCakeQuery(callable $factory, PaginationResult $expected)
+    public function testPaginateCakeQuery(callable $factory, PaginationResult $expected): void
     {
         $controller = new Controller();
         $controller->loadComponent('Paginator');
@@ -61,7 +64,7 @@ class PaginatorTest extends TestCase
      * @dataProvider valueProvider
      * @dataProvider queryExpressionProvider
      */
-    public function testPaginateLampagerCakeQuery(callable $factory)
+    public function testPaginateLampagerCakeQuery(callable $factory): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Lampager\Cake\ORM\Query cannot be paginated by Lampager\Cake\Datasource\Paginator::paginate()');
@@ -80,7 +83,7 @@ class PaginatorTest extends TestCase
         $controller->paginate($query);
     }
 
-    public function valueProvider()
+    public function valueProvider(): Generator
     {
         yield 'Ascending forward start inclusive' => [
             function () {
@@ -729,7 +732,7 @@ class PaginatorTest extends TestCase
         ];
     }
 
-    public function queryExpressionProvider()
+    public function queryExpressionProvider(): Generator
     {
         yield 'Ascending forward start inclusive with QueryExpression' => [
             function () {

--- a/tests/TestCase/Model/ArrayProcessorTest.php
+++ b/tests/TestCase/Model/ArrayProcessorTest.php
@@ -23,7 +23,7 @@ class ArrayProcessorTest extends TestCase
      * @param Entity[] $rows
      * @dataProvider processProvider
      */
-    public function testProcess(array $options, $cursor, array $rows, PaginationResult $expected): void
+    public function testProcess(array $options, ?array $cursor, array $rows, PaginationResult $expected): void
     {
         /** @var MockObject&Table $repository */
         $repository = $this->createMock(Table::class);

--- a/tests/TestCase/Model/ArrayProcessorTest.php
+++ b/tests/TestCase/Model/ArrayProcessorTest.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Lampager\Cake\Test\TestCase\Model;
 
 use Cake\I18n\Time;
 use Cake\ORM\Entity;
 use Cake\ORM\Table;
+use Generator;
 use Lampager\Cake\ArrayProcessor;
 use Lampager\Cake\ORM\Query;
 use Lampager\Cake\PaginationResult;
@@ -20,7 +23,7 @@ class ArrayProcessorTest extends TestCase
      * @param Entity[] $rows
      * @dataProvider processProvider
      */
-    public function testProcess(array $options, $cursor, array $rows, PaginationResult $expected)
+    public function testProcess(array $options, $cursor, array $rows, PaginationResult $expected): void
     {
         /** @var MockObject&Table $repository */
         $repository = $this->createMock(Table::class);
@@ -39,7 +42,7 @@ class ArrayProcessorTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function processProvider()
+    public function processProvider(): Generator
     {
         yield 'Option has prefix but entity does not have prefix' => [
             [

--- a/tests/TestCase/Model/Behavior/LampagerBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/LampagerBehaviorTest.php
@@ -21,7 +21,6 @@ class LampagerBehaviorTest extends TestCase
     ];
 
     /**
-     * @param LampagerBehavior&Table $factory
      * @dataProvider valueProvider
      * @dataProvider queryExpressionProvider
      */

--- a/tests/TestCase/Model/Behavior/LampagerBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/LampagerBehaviorTest.php
@@ -1,11 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Lampager\Cake\Test\TestCase\Model\Behavior;
 
 use Cake\I18n\Time;
 use Cake\ORM\Entity;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
+use Generator;
 use Lampager\Cake\Model\Behavior\LampagerBehavior;
 use Lampager\Cake\ORM\Query;
 use Lampager\Cake\Test\TestCase\TestCase;
@@ -22,7 +25,7 @@ class LampagerBehaviorTest extends TestCase
      * @dataProvider valueProvider
      * @dataProvider queryExpressionProvider
      */
-    public function testLampager(callable $factory, PaginationResult $expected)
+    public function testLampager(callable $factory, PaginationResult $expected): void
     {
         /** @var LampagerBehavior&Table $posts */
         $posts = TableRegistry::getTableLocator()->get('Posts');
@@ -33,7 +36,7 @@ class LampagerBehaviorTest extends TestCase
         $this->assertJsonEquals($expected, $query->all());
     }
 
-    public function valueProvider()
+    public function valueProvider(): Generator
     {
         yield 'Ascending forward start inclusive' => [
             function (Table $posts) {
@@ -650,7 +653,7 @@ class LampagerBehaviorTest extends TestCase
         ];
     }
 
-    public function queryExpressionProvider()
+    public function queryExpressionProvider(): Generator
     {
         yield 'Ascending forward start inclusive with QueryExpression' => [
             function (Table $posts) {

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -42,7 +42,6 @@ class QueryTest extends TestCase
     }
 
     /**
-     * @param PaginationResult $expected
      * @dataProvider orderProvider
      */
     public function testOrderClear(callable $factory): void
@@ -65,7 +64,7 @@ class QueryTest extends TestCase
         $this->expectException(BadKeywordException::class);
         $this->expectExceptionMessage('OrderClauseExpression does not have direction');
 
-        /** @var MockObject&OrderClauseExpression */
+        /** @var MockObject&OrderClauseExpression $expression */
         $expression = $this->getMockBuilder(OrderClauseExpression::class)->disableOriginalConstructor()->getMock();
         $expression->method('sql')->willReturn('modified');
 
@@ -301,10 +300,9 @@ class QueryTest extends TestCase
     }
 
     /**
-     * @param int $expected
      * @dataProvider countProvider
      */
-    public function testCount(callable $factory, $expected): void
+    public function testCount(callable $factory, int $expected): void
     {
         /** @var LampagerBehavior&Table $posts */
         $posts = TableRegistry::getTableLocator()->get('Posts');

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Lampager\Cake\Test\TestCase\ORM;
 
 use Cake\Database\Expression\OrderClauseExpression;
@@ -7,6 +9,7 @@ use Cake\I18n\Time;
 use Cake\ORM\Entity;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
+use Generator;
 use Lampager\Cake\Model\Behavior\LampagerBehavior;
 use Lampager\Cake\ORM\Query;
 use Lampager\Cake\PaginationResult;
@@ -27,7 +30,7 @@ class QueryTest extends TestCase
     /**
      * @dataProvider orderProvider
      */
-    public function testOrder(callable $factory, PaginationResult $expected)
+    public function testOrder(callable $factory, PaginationResult $expected): void
     {
         /** @var LampagerBehavior&Table $posts */
         $posts = TableRegistry::getTableLocator()->get('Posts');
@@ -42,7 +45,7 @@ class QueryTest extends TestCase
      * @param PaginationResult $expected
      * @dataProvider orderProvider
      */
-    public function testOrderClear(callable $factory)
+    public function testOrderClear(callable $factory): void
     {
         $this->expectException(LampagerException::class);
         $this->expectExceptionMessage('At least one order constraint required');
@@ -57,7 +60,7 @@ class QueryTest extends TestCase
         $query->all();
     }
 
-    public function testOrderIllegal()
+    public function testOrderIllegal(): void
     {
         $this->expectException(BadKeywordException::class);
         $this->expectExceptionMessage('OrderClauseExpression does not have direction');
@@ -74,7 +77,7 @@ class QueryTest extends TestCase
             ->all();
     }
 
-    public function testOrderQueryExpression()
+    public function testOrderQueryExpression(): void
     {
         /** @var LampagerBehavior&Table $posts */
         $posts = TableRegistry::getTableLocator()->get('Posts');
@@ -107,7 +110,7 @@ class QueryTest extends TestCase
         $this->assertJsonEquals($expected, $actual);
     }
 
-    public function testLimitQueryExpression()
+    public function testLimitQueryExpression(): void
     {
         /** @var LampagerBehavior&Table $posts */
         $posts = TableRegistry::getTableLocator()->get('Posts');
@@ -140,7 +143,7 @@ class QueryTest extends TestCase
         $this->assertJsonEquals($expected, $actual);
     }
 
-    public function testLimitIllegalQueryExpression()
+    public function testLimitIllegalQueryExpression(): void
     {
         $this->expectException(LimitParameterException::class);
         $this->expectExceptionMessage('Limit must be positive integer');
@@ -155,7 +158,7 @@ class QueryTest extends TestCase
             ->all();
     }
 
-    public function testWhere()
+    public function testWhere(): void
     {
         /** @var LampagerBehavior&Table $posts */
         $posts = TableRegistry::getTableLocator()->get('Posts');
@@ -189,7 +192,7 @@ class QueryTest extends TestCase
         $this->assertJsonEquals($expected, $actual);
     }
 
-    public function testGroup()
+    public function testGroup(): void
     {
         $this->expectException(InsufficientConstraintsException::class);
         $this->expectExceptionMessage('group()/union() are not supported');
@@ -204,7 +207,7 @@ class QueryTest extends TestCase
             ->all();
     }
 
-    public function testUnion()
+    public function testUnion(): void
     {
         $this->expectException(InsufficientConstraintsException::class);
         $this->expectExceptionMessage('group()/union() are not supported');
@@ -219,7 +222,7 @@ class QueryTest extends TestCase
             ->all();
     }
 
-    public function testCall()
+    public function testCall(): void
     {
         /** @var LampagerBehavior&Table $posts */
         $posts = TableRegistry::getTableLocator()->get('Posts');
@@ -239,7 +242,7 @@ class QueryTest extends TestCase
         $this->assertJsonEquals($expected, $actual);
     }
 
-    public function testDebugInfo()
+    public function testDebugInfo(): void
     {
         /** @var LampagerBehavior&Table $posts */
         $posts = TableRegistry::getTableLocator()->get('Posts');
@@ -269,7 +272,7 @@ class QueryTest extends TestCase
         $this->assertArrayHasKey('extraOptions', $actual);
     }
 
-    public function testDebugInfoIncomplete()
+    public function testDebugInfoIncomplete(): void
     {
         /** @var LampagerBehavior&Table $posts */
         $posts = TableRegistry::getTableLocator()->get('Posts');
@@ -301,7 +304,7 @@ class QueryTest extends TestCase
      * @param int $expected
      * @dataProvider countProvider
      */
-    public function testCount(callable $factory, $expected)
+    public function testCount(callable $factory, $expected): void
     {
         /** @var LampagerBehavior&Table $posts */
         $posts = TableRegistry::getTableLocator()->get('Posts');
@@ -310,7 +313,7 @@ class QueryTest extends TestCase
         $this->assertSame($expected, $factory($posts));
     }
 
-    public function orderProvider()
+    public function orderProvider(): Generator
     {
         yield 'Ascending and ascending' => [
             function (Table $posts) {
@@ -391,7 +394,7 @@ class QueryTest extends TestCase
         ];
     }
 
-    public function countProvider()
+    public function countProvider(): Generator
     {
         yield 'Ascending forward start inclusive' => [
             function (Table $posts) {

--- a/tests/TestCase/PaginationResultTest.php
+++ b/tests/TestCase/PaginationResultTest.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Lampager\Cake\Test\TestCase;
 
 use ArrayIterator;
 use Cake\I18n\Time;
 use Cake\ORM\Entity;
+use Generator;
 use IteratorAggregate;
 use Lampager\Cake\PaginationResult;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -19,7 +22,7 @@ class PaginationResultTest extends TestCase
      * @dataProvider arrayProvider
      * @dataProvider iteratorAggregateProvider
      */
-    public function testIteratorCurrent(array $entities, $records, array $meta)
+    public function testIteratorCurrent(array $entities, $records, array $meta): void
     {
         $actual = new PaginationResult($records, $meta);
 
@@ -51,7 +54,7 @@ class PaginationResultTest extends TestCase
      * @dataProvider arrayProvider
      * @dataProvider iteratorAggregateProvider
      */
-    public function testIteratorKey(array $entities, $records, array $meta)
+    public function testIteratorKey(array $entities, $records, array $meta): void
     {
         $actual = new PaginationResult($records, $meta);
 
@@ -83,7 +86,7 @@ class PaginationResultTest extends TestCase
      * @dataProvider arrayProvider
      * @dataProvider iteratorAggregateProvider
      */
-    public function testIteratorNext(array $entities, $records, array $meta)
+    public function testIteratorNext(array $entities, $records, array $meta): void
     {
         $actual = new PaginationResult($records, $meta);
 
@@ -113,7 +116,7 @@ class PaginationResultTest extends TestCase
      * @dataProvider arrayProvider
      * @dataProvider iteratorAggregateProvider
      */
-    public function testIteratorValid(array $entities, $records, array $meta)
+    public function testIteratorValid(array $entities, $records, array $meta): void
     {
         $actual = new PaginationResult($records, $meta);
 
@@ -144,11 +147,10 @@ class PaginationResultTest extends TestCase
      * @param Entity[]                     $entities
      * @param Entity[]|Traversable<Entity> $records
      * @param mixed[]                      $meta
-     * @param string                       $expected
      * @dataProvider arrayProvider
      * @dataProvider iteratorAggregateProvider
      */
-    public function testJsonSerialize(array $entities, $records, array $meta, $expected)
+    public function testJsonSerialize(array $entities, $records, array $meta, string $expected): void
     {
         $actual = json_encode(new PaginationResult($records, $meta));
         $this->assertJsonStringEqualsJsonString($expected, $actual);
@@ -161,7 +163,7 @@ class PaginationResultTest extends TestCase
      * @dataProvider arrayProvider
      * @dataProvider iteratorAggregateProvider
      */
-    public function testSerializeAndUnserialize(array $entities, $records, array $meta)
+    public function testSerializeAndUnserialize(array $entities, $records, array $meta): void
     {
         $actual = unserialize(serialize(new PaginationResult($records, $meta)));
         $expected = new PaginationResult($records, $meta);
@@ -175,7 +177,7 @@ class PaginationResultTest extends TestCase
      * @dataProvider arrayProvider
      * @dataProvider iteratorAggregateProvider
      */
-    public function testDebugInfo(array $entities, $records, array $meta)
+    public function testDebugInfo(array $entities, $records, array $meta): void
     {
         $actual = (new PaginationResult($records, $meta))->__debugInfo();
 
@@ -189,7 +191,7 @@ class PaginationResultTest extends TestCase
         ], $actual);
     }
 
-    public function arrayProvider()
+    public function arrayProvider(): Generator
     {
         yield 'Array iteration' => [
             [
@@ -318,7 +320,7 @@ class PaginationResultTest extends TestCase
         ];
     }
 
-    public function iteratorAggregateProvider()
+    public function iteratorAggregateProvider(): Generator
     {
         /** @var IteratorAggregate&MockObject $iteratorAggregate */
         $iteratorAggregate = $this->getMockForAbstractClass(IteratorAggregate::class);

--- a/tests/TestCase/PaginatorTest.php
+++ b/tests/TestCase/PaginatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Lampager\Cake\Test\TestCase;
 
 use Lampager\Cake\ORM\Query;
@@ -9,7 +11,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 class PaginatorTest extends TestCase
 {
-    public function testDebugInfo()
+    public function testDebugInfo(): void
     {
         /** @var MockObject&Query */
         $builder = $this->getMockBuilder(Query::class)

--- a/tests/TestCase/TestCase.php
+++ b/tests/TestCase/TestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Lampager\Cake\Test\TestCase;
 
 use Cake\TestSuite\TestCase as BaseTestCase;
@@ -12,25 +14,18 @@ abstract class TestCase extends BaseTestCase
      *
      * @param  mixed                                                        $expected
      * @param  mixed                                                        $actual
-     * @param  string                                                       $message
      * @throws \PHPUnit\Framework\ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
-     * @return void
      */
-    public function assertJsonEquals($expected, $actual, $message = '')
+    public function assertJsonEquals($expected, $actual, string $message = ''): void
     {
         $this->assertJsonStringEqualsJsonString(json_encode($expected), json_encode($actual), $message);
     }
 
     /**
      * Asserts that two given SQL query statements are equal.
-     *
-     * @param  string $expected
-     * @param  string $actual
-     * @param  string $message
-     * @return void
      */
-    public function assertSqlEquals($expected, $actual, $message = '')
+    public function assertSqlEquals(string $expected, string $actual, string $message = ''): void
     {
         $formatter = new Formatter();
         $this->assertSame($formatter->format($expected), $formatter->format($actual), $message);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\Database\Connection;

--- a/tests/test_app/Application.php
+++ b/tests/test_app/Application.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Lampager\Cake\TestApp;
 
 use Cake\Http\BaseApplication;


### PR DESCRIPTION
This PR supports CakePHP 4.x, which is backward incompatible release with CakePHP 3.x. As CakePHP plugins cannot support multiple major versions of CakePHP, this is going to be separately maintained from the 1.x (for CakePHP 3.x).