### PR TITLE
Update SQL tests to consistently pass

### DIFF
--- a/tests/TestCase/Database/SqliteCompilerTest.php
+++ b/tests/TestCase/Database/SqliteCompilerTest.php
@@ -26,11 +26,11 @@ class SqliteCompilerTest extends TestCase
 
         $expected = '
             SELECT
-                Posts.* AS "Posts__*"
+                "Posts".* AS "Posts__*"
             FROM
-                posts Posts
+                "posts" "Posts"
             ORDER BY
-                modified ASC
+                "modified" ASC
         ';
 
         $actual = $posts->find()
@@ -51,14 +51,14 @@ class SqliteCompilerTest extends TestCase
             FROM
                 (
                     SELECT
-                        Posts.id AS "Posts__id",
-                        Posts.modified AS "Posts__modified"
+                        "Posts"."id" AS "Posts__id",
+                        "Posts"."modified" AS "Posts__modified"
                     FROM
-                        posts Posts
+                        "posts" "Posts"
                     WHERE
-                        id > :c0
+                        "id" > :c0
                     ORDER BY
-                        modified ASC
+                        "modified" ASC
                 )
             UNION ALL
             SELECT
@@ -66,12 +66,12 @@ class SqliteCompilerTest extends TestCase
             FROM
                 (
                     SELECT
-                        Posts.id AS "Posts__id",
-                        Posts.modified AS "Posts__modified"
+                        "Posts"."id" AS "Posts__id",
+                        "Posts"."modified" AS "Posts__modified"
                     FROM
-                        posts Posts
+                        "posts" "Posts"
                     ORDER BY
-                        modified ASC
+                        "modified" ASC
                 )
         ';
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -35,7 +35,7 @@ Cache::setConfig([
 ]);
 
 if (!getenv('DB_DSN')) {
-    putenv('DB_DSN=sqlite:///:memory:?className=' . Connection::class . '&driver=' . Sqlite::class);
+    putenv('DB_DSN=sqlite:///:memory:?className=' . Connection::class . '&driver=' . Sqlite::class . '&quoteIdentifiers=true');
 }
 
 ConnectionManager::setConfig('test', [


### PR DESCRIPTION
Updates tests for `SqliteCompiler` because CakePHP \>= 4.0.3 changed the way it handled quotations around the identifiers. Now we enforce them being quoted so it works consistenly among any versions.