### PR TITLE
Allows accessing public properties

### DIFF
--- a/src/PaginationResult.php
+++ b/src/PaginationResult.php
@@ -144,6 +144,26 @@ class PaginationResult implements ResultSetInterface
     }
 
     /**
+     * @param string $name The name of the parameter to fetch
+     *
+     * @return mixed
+     */
+    public function __get($name)
+    {
+        if (property_exists($this->result, $name)) {
+            return $this->result->{$name};
+        }
+
+        $trace = debug_backtrace();
+        trigger_error(
+            'Undefined property via __get(): ' . $name . ' in ' . $trace[0]['file'] . ' on line ' . $trace[0]['line'],
+            E_USER_NOTICE
+        );
+
+        return null;
+    }    
+    
+    /**
      * Returns an array that can be used to describe the internal state of this
      * object.
      */

--- a/src/PaginationResult.php
+++ b/src/PaginationResult.php
@@ -148,7 +148,7 @@ class PaginationResult implements ResultSetInterface
      *
      * @return mixed
      */
-    public function __get($name)
+    public function __get(string $name)
     {
         if (property_exists($this->result, $name)) {
             return $this->result->{$name};

--- a/tests/TestCase/PaginationResultTest.php
+++ b/tests/TestCase/PaginationResultTest.php
@@ -191,6 +191,23 @@ class PaginationResultTest extends TestCase
         ], $actual);
     }
 
+    /**
+     * @param Entity[] $entities
+     * @param Entity[]|Traversable<Entity> $records
+     * @param mixed[] $meta
+     * @dataProvider arrayProvider
+     * @dataProvider iteratorAggregateProvider
+     */
+    public function testPublicProperties(array $entities, $records, array $meta): void
+    {
+        $paginationResult = new PaginationResult($records, $meta);
+
+        $this->assertEquals($meta['hasPrevious'], $paginationResult->hasPrevious);
+        $this->assertEquals($meta['previousCursor'], $paginationResult->previousCursor);
+        $this->assertEquals($meta['hasNext'], $paginationResult->hasNext);
+        $this->assertEquals($meta['nextCursor'], $paginationResult->nextCursor);
+    }
+
     public function arrayProvider(): Generator
     {
         yield 'Array iteration' => [


### PR DESCRIPTION
This allows accessing public properties of the underlying `Lampager\PaginationResult` object (For example, `hasNext`, `nextCursor`, etc.)