### PR TITLE
Add support for EagerLoader

### DIFF
--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -105,7 +105,8 @@ class Paginator extends BasePaginator
             ->where($this->builder->clause('where'))
             ->modifier($this->builder->clause('modifier'))
             ->join($this->builder->clause('join'))
-            ->epilog($this->builder->clause('epilog'));
+            ->epilog($this->builder->clause('epilog'))
+            ->setEagerLoader($this->builder->getEagerLoader());
 
         $this
             ->compileWhere($builder, $select)
@@ -146,8 +147,14 @@ class Paginator extends BasePaginator
      */
     protected function compileOrderBy(Query $builder, Select $select)
     {
+        $alias = $builder->getRepository()->getAlias();
+
         foreach ($select->orders() as $i => $order) {
-            $builder->order([$order->column() => $order->order()], $i === 0);
+            $column = $order->column();
+            if (strpos($column, '.') === false) {
+                $column = $alias . '.' . $column;
+            }
+            $builder->order([$column => $order->order()], $i === 0);
         }
         return $this;
     }


### PR DESCRIPTION
As reported in #29, EagerLoader is silently dropped for now. This PR adds support for EagerLoader just referencing the original EagerLoader instance when compiling the query.