### PR TITLE
Add support for PHP 8.2 and drop support for PHP 7.2 and 7.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,10 @@ jobs:
     strategy:
       matrix:
         php:
-          - 7.2
-          - 7.3
           - 7.4
           - 8.0
           - 8.1
+          - 8.2
         dsn:
           - ''
           - mysql://lampager_test:lampager_test@127.0.0.1/lampager_test
@@ -82,7 +81,7 @@ jobs:
         run: |
           vendor/bin/phpunit
       - name: Coverage
-        if: ${{ matrix.php == 8.1 }}
+        if: ${{ matrix.php == 8.2 }}
         env:
           COVERALLS_REPO_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI Workflow
 on:
-  - push
+  pull_request:
+  push:
+    branches:
+      - master
+      - v1.x
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Rapid pagination without using OFFSET
 
 ## Requirements
 
-- PHP: ^7.2 || ^8.0
+- PHP: ^7.4 || ^8.0
 - CakePHP: ^4.0
 - [lampager/lampager][]: ^0.4
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     },
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "cakephp/cakephp": "^4.0",
         "lampager/lampager": "^0.4"
     },


### PR DESCRIPTION
This PR bumps the minimum requirement of PHP from 7.2 to 7.4 as in CakePHP 4.4.