### PR TITLE
Update requirement to cakephp/cakephp@^4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Rapid pagination without using OFFSET
 ## Requirements
 
 - PHP: ^7.4 || ^8.0
-- CakePHP: ^4.0
+- CakePHP: ^4.4
 - [lampager/lampager][]: ^0.4
 
 ### Note
@@ -41,9 +41,8 @@ methods:
 
 ### Use in Controller
 
-At first, load the default Paginator component with the
-`\Lampager\Cake\Datasource\Paginator` in your Controller class (`AppController`
-is preferable).
+At first, configure `$paginate` to use `\Lampager\Cake\Datasource\Paginator` in
+your Controller class.
 
 ```php
 namespace App\Controller;
@@ -53,14 +52,9 @@ use Lampager\Cake\Datasource\Paginator;
 
 class AppController extends Controller
 {
-    public function initialize(): void
-    {
-        parent::initialize();
-
-        $this->loadComponent('Paginator', [
-            'paginator' => new Paginator(),
-        ]);
-    }
+    public $paginate = [
+        'className' => Paginator::class,
+    ];
 }
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "php": "^7.4 || ^8.0",
-        "cakephp/cakephp": "^4.0",
+        "cakephp/cakephp": "^4.4",
         "lampager/lampager": "^0.4"
     },
     "require-dev": {

--- a/src/Model/Behavior/LampagerBehavior.php
+++ b/src/Model/Behavior/LampagerBehavior.php
@@ -17,16 +17,4 @@ class LampagerBehavior extends Behavior
 
         return $query;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function table(): Table
-    {
-        if (is_callable('parent::' . __FUNCTION__)) {
-            return parent::table();
-        }
-
-        return $this->getTable();
-    }
 }


### PR DESCRIPTION
This PR reflects the changes by #32 which makes lampager-cakephp be only compatible with `cakephp/cakephp@^4.4`. The next version of lampager-cakephp will be shipped with the new requirement, so here updates the documentation and the code for backward compatibility with `cakephp/cakephp@~4.1` is removed as well.