### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,5 +414,5 @@ return [
 [lampager/lampager]:              https://github.com/lampager/lampager
 [lampager/lampager-cakephp v1.x]: https://github.com/lampager/lampager-cakephp/tree/v1.x
 [lampager/lampager-cakephp2]:     https://github.com/lampager/lampager-cakephp2
-[Pagination]:                     https://book.cakephp.org/4/en/controllers/components/pagination.html
+[Pagination]:                     https://book.cakephp.org/4/en/controllers/pagination.html
 [Working with Result Sets]:       https://book.cakephp.org/4/en/orm/retrieving-data-and-resultsets.html#working-with-result-sets

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "lampager/lampager-cakephp",
-    "description": "Rapid pagination for CakePHP 3",
+    "description": "Rapid pagination for CakePHP 4",
     "type": "cakephp-plugin",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
This PR replaces the link to the official documentation on the Pagination component that has been deprecated since the release of cakephp/cakephp@4.4.