### PR TITLE
Remove use of the deprecated `TestFixture::$fields`

### DIFF
--- a/tests/Fixture/PostsFixture.php
+++ b/tests/Fixture/PostsFixture.php
@@ -8,17 +8,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 
 class PostsFixture extends TestFixture
 {
-    public $fields = [
-        'id' => ['type' => 'integer'],
-        'modified' => ['type' => 'datetime'],
-        '_constraints' => [
-            'primary' => [
-                'type' => 'primary',
-                'columns' => ['id'],
-            ],
-        ],
-    ];
-
     public $records = [
         ['id' => 1, 'modified' => '2017-01-01 10:00:00'],
         ['id' => 3, 'modified' => '2017-01-01 10:00:00'],


### PR DESCRIPTION
Follows up for #32 