### PR TITLE
Fix tests for `Lampager\Cake\ORM\Query::__call()` not covered its target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         run: |
           vendor/bin/phpunit
       - name: Coverage
-        if: ${{ matrix.php == 8.2 }}
+        if: ${{ matrix.php == 8.2 && matrix.dsn == '' }}
         env:
           COVERALLS_REPO_TOKEN: ${{ github.token }}
         run: |

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -27,6 +27,25 @@ class QueryTest extends TestCase
         'plugin.Lampager\\Cake.Posts',
     ];
 
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        set_error_handler(
+            static function ($errno, $errstr, $errfile, $errline) {
+                throw new \ErrorException($errstr, 0, $errno, $errfile, $errline);
+            },
+            E_ALL
+        );
+    }
+
+    public function tearDown(): void
+    {
+        restore_error_handler();
+
+        parent::tearDown();
+    }
+
     /**
      * @dataProvider orderProvider
      */
@@ -223,23 +242,15 @@ class QueryTest extends TestCase
 
     public function testCall(): void
     {
+        $this->expectException(\ErrorException::class);
+        $this->expectExceptionMessage('You must call `all()` first');
+
         /** @var LampagerBehavior&Table $posts */
         $posts = TableRegistry::getTableLocator()->get('Posts');
         $posts->addBehavior(LampagerBehavior::class);
-
-        $actual = $posts->lampager()
+        $posts->lampager()
             ->orderAsc('id')
-            ->all()
             ->take();
-
-        $expected = [
-            new Entity([
-                'id' => 1,
-                'modified' => new FrozenTime('2017-01-01 10:00:00'),
-            ]),
-        ];
-
-        $this->assertJsonEquals($expected, $actual);
     }
 
     public function testDebugInfo(): void

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,6 +10,8 @@ use Lampager\Cake\Database\Driver\Sqlite;
 require_once __DIR__ . '/../vendor/cakephp/cakephp/src/basics.php';
 require_once __DIR__ . '/../vendor/autoload.php';
 
+define('ROOT', dirname(__DIR__));
+
 ConnectionManager::setConfig('test', [
     'url' => env('DB_DSN') ?: 'sqlite:///:memory:?className=' . Connection::class . '&driver=' . Sqlite::class . '&quoteIdentifiers=true',
 ]);


### PR DESCRIPTION
The line `->all()` was added to handle a deprecation warning in #32, which was wrong because it changed the original behavior in that test. The deprecation warning itself proved that the `Lampager\Cake\ORM\Query::__call()` properly delegated to the parent method, `Cake\ORM\Query::__call()` and `Cake\Datasource\QueryTrait::__call()`, which **is** deprecated.