### PR TITLE
Run CI tests on the latest postgres (backport)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           --health-timeout=30s
           --health-retries=5
       postgres:
-        image: postgres:13.3
+        image: postgres:15.2
         ports:
           - '5432:5432'
         env:


### PR DESCRIPTION
Back port #35 for v1.x (CakePHP 3.x)