### PR TITLE
Update requirement to cakephp/cakephp@^4.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
           - 8.0
           - 8.1
           - 8.2
+          - 8.3
         dsn:
           - ''
           - mysql://lampager_test:lampager_test@127.0.0.1/lampager_test
@@ -78,10 +79,12 @@ jobs:
         env:
           DB_DSN: ${{ matrix.dsn }}
         run: |
-          vendor/bin/phpunit
+          composer test
       - name: Coverage
-        if: ${{ matrix.php == 8.2 && matrix.dsn == '' }}
+        if: ${{ matrix.php == 8.3 && matrix.dsn == '' }}
         env:
           COVERALLS_REPO_TOKEN: ${{ github.token }}
         run: |
-          vendor/bin/php-coveralls --verbose
+          export PATH=$(composer config --global home):$PATH
+          composer global require 'php-coveralls/php-coveralls:*'
+          php-coveralls --verbose

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Rapid pagination without using OFFSET
 ## Requirements
 
 - PHP: ^7.4 || ^8.0
-- CakePHP: ^4.4
+- CakePHP: ^4.5
 - [lampager/lampager][]: ^0.4
 
 ### Note
@@ -144,9 +144,9 @@ $drafts = $this->lampager()
     ->seekable()
     ->cursor($cursor)
     ->limit(10)
-    ->orderDesc($this->query()->newExpr('modified'))
-    ->orderDesc($this->query()->newExpr('created'))
-    ->orderDesc($this->query()->newExpr('id'));
+    ->orderDesc($this->selectQuery()->newExpr('modified'))
+    ->orderDesc($this->selectQuery()->newExpr('created'))
+    ->orderDesc($this->selectQuery()->newExpr('id'));
 
 /** @var \Cake\ORM\Entity $sample */
 $sample = $drafts->sample();
@@ -288,6 +288,8 @@ namespace App\Controller;
 
 class PostsController extends AppController
 {
+    public $Posts = null;
+
     /**
      * This method shows how to pass options by a query and array.
      */

--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,11 @@
     },
     "require": {
         "php": "^7.4 || ^8.0",
-        "cakephp/cakephp": "^4.4",
+        "cakephp/cakephp": "^4.5",
         "lampager/lampager": "^0.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0 || ^9.0",
-        "php-coveralls/php-coveralls": "^2.4",
         "nilportugues/sql-query-formatter": "^1.2"
     },
     "scripts": {

--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -101,7 +101,7 @@ class Paginator extends BasePaginator
         $repository = $this->builder->getRepository();
 
         /** @var Query $builder */
-        $builder = $repository->query()
+        $builder = $repository->selectQuery()
             ->where($this->builder->clause('where'))
             ->modifier($this->builder->clause('modifier'))
             ->join($this->builder->clause('join'))

--- a/tests/TestCase/Datasource/PaginatorTest.php
+++ b/tests/TestCase/Datasource/PaginatorTest.php
@@ -32,6 +32,7 @@ class PaginatorTest extends TestCase
     public function testPaginateTable(callable $factory, PaginationResult $expected): void
     {
         $controller = new Controller();
+        $controller->Posts = null;
         $controller->paginate = [
             'className' => Paginator::class,
         ];
@@ -51,6 +52,7 @@ class PaginatorTest extends TestCase
     public function testPaginateCakeQuery(callable $factory, PaginationResult $expected): void
     {
         $controller = new Controller();
+        $controller->Posts = null;
         $controller->paginate = [
             'className' => Paginator::class,
         ];
@@ -73,6 +75,7 @@ class PaginatorTest extends TestCase
         $this->expectExceptionMessage('Lampager\Cake\ORM\Query cannot be paginated by Lampager\Cake\Datasource\Paginator::paginate()');
 
         $controller = new Controller();
+        $controller->Posts = null;
         $controller->paginate = [
             'className' => Paginator::class,
         ];
@@ -93,6 +96,7 @@ class PaginatorTest extends TestCase
         $this->expectExceptionMessage('No repository set for query.');
 
         $controller = new Controller();
+        $controller->Posts = null;
         $controller->paginate = [
             'className' => Paginator::class,
         ];

--- a/tests/TestCase/Model/Behavior/LampagerBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/LampagerBehaviorTest.php
@@ -661,8 +661,8 @@ class LampagerBehaviorTest extends TestCase
                     ->forward()
                     ->seekable()
                     ->limit(3)
-                    ->orderAsc($posts->query()->expr('modified'))
-                    ->orderAsc($posts->query()->expr('id'));
+                    ->orderAsc($posts->selectQuery()->expr('modified'))
+                    ->orderAsc($posts->selectQuery()->expr('id'));
             },
             new PaginationResult(
                 [
@@ -698,8 +698,8 @@ class LampagerBehaviorTest extends TestCase
                     ->forward()
                     ->seekable()
                     ->limit(3)
-                    ->orderAsc($posts->query()->expr('modified'))
-                    ->orderAsc($posts->query()->expr('id'))
+                    ->orderAsc($posts->selectQuery()->expr('modified'))
+                    ->orderAsc($posts->selectQuery()->expr('id'))
                     ->cursor([
                         'id' => 3,
                         'modified' => new FrozenTime('2017-01-01 10:00:00'),
@@ -743,8 +743,8 @@ class LampagerBehaviorTest extends TestCase
                     ->seekable()
                     ->exclusive()
                     ->limit(3)
-                    ->orderAsc($posts->query()->expr('modified'))
-                    ->orderAsc($posts->query()->expr('id'))
+                    ->orderAsc($posts->selectQuery()->expr('modified'))
+                    ->orderAsc($posts->selectQuery()->expr('id'))
                     ->cursor([
                         'id' => 3,
                         'modified' => new FrozenTime('2017-01-01 10:00:00'),
@@ -784,8 +784,8 @@ class LampagerBehaviorTest extends TestCase
                     ->backward()
                     ->seekable()
                     ->limit(3)
-                    ->orderAsc($posts->query()->expr('modified'))
-                    ->orderAsc($posts->query()->expr('id'));
+                    ->orderAsc($posts->selectQuery()->expr('modified'))
+                    ->orderAsc($posts->selectQuery()->expr('id'));
             },
             new PaginationResult(
                 [
@@ -822,8 +822,8 @@ class LampagerBehaviorTest extends TestCase
                     ->seekable()
                     ->exclusive()
                     ->limit(3)
-                    ->orderAsc($posts->query()->expr('modified'))
-                    ->orderAsc($posts->query()->expr('id'));
+                    ->orderAsc($posts->selectQuery()->expr('modified'))
+                    ->orderAsc($posts->selectQuery()->expr('id'));
             },
             new PaginationResult(
                 [
@@ -859,8 +859,8 @@ class LampagerBehaviorTest extends TestCase
                     ->backward()
                     ->seekable()
                     ->limit(3)
-                    ->orderAsc($posts->query()->expr('modified'))
-                    ->orderAsc($posts->query()->expr('id'))
+                    ->orderAsc($posts->selectQuery()->expr('modified'))
+                    ->orderAsc($posts->selectQuery()->expr('id'))
                     ->cursor([
                         'id' => 3,
                         'modified' => new FrozenTime('2017-01-01 10:00:00'),
@@ -897,8 +897,8 @@ class LampagerBehaviorTest extends TestCase
                     ->seekable()
                     ->exclusive()
                     ->limit(3)
-                    ->orderAsc($posts->query()->expr('modified'))
-                    ->orderAsc($posts->query()->expr('id'))
+                    ->orderAsc($posts->selectQuery()->expr('modified'))
+                    ->orderAsc($posts->selectQuery()->expr('id'))
                     ->cursor([
                         'id' => 3,
                         'modified' => new FrozenTime('2017-01-01 10:00:00'),
@@ -930,8 +930,8 @@ class LampagerBehaviorTest extends TestCase
                     ->forward()
                     ->seekable()
                     ->limit(3)
-                    ->orderDesc($posts->query()->expr('modified'))
-                    ->orderDesc($posts->query()->expr('id'));
+                    ->orderDesc($posts->selectQuery()->expr('modified'))
+                    ->orderDesc($posts->selectQuery()->expr('id'));
             },
             new PaginationResult(
                 [
@@ -968,8 +968,8 @@ class LampagerBehaviorTest extends TestCase
                     ->seekable()
                     ->exclusive()
                     ->limit(3)
-                    ->orderDesc($posts->query()->expr('modified'))
-                    ->orderDesc($posts->query()->expr('id'));
+                    ->orderDesc($posts->selectQuery()->expr('modified'))
+                    ->orderDesc($posts->selectQuery()->expr('id'));
             },
             new PaginationResult(
                 [
@@ -1005,8 +1005,8 @@ class LampagerBehaviorTest extends TestCase
                     ->forward()
                     ->seekable()
                     ->limit(3)
-                    ->orderDesc($posts->query()->expr('modified'))
-                    ->orderDesc($posts->query()->expr('id'))
+                    ->orderDesc($posts->selectQuery()->expr('modified'))
+                    ->orderDesc($posts->selectQuery()->expr('id'))
                     ->cursor([
                         'id' => 3,
                         'modified' => new FrozenTime('2017-01-01 10:00:00'),
@@ -1043,8 +1043,8 @@ class LampagerBehaviorTest extends TestCase
                     ->seekable()
                     ->exclusive()
                     ->limit(3)
-                    ->orderDesc($posts->query()->expr('modified'))
-                    ->orderDesc($posts->query()->expr('id'))
+                    ->orderDesc($posts->selectQuery()->expr('modified'))
+                    ->orderDesc($posts->selectQuery()->expr('id'))
                     ->cursor([
                         'id' => 3,
                         'modified' => new FrozenTime('2017-01-01 10:00:00'),
@@ -1076,8 +1076,8 @@ class LampagerBehaviorTest extends TestCase
                     ->backward()
                     ->seekable()
                     ->limit(3)
-                    ->orderDesc($posts->query()->expr('modified'))
-                    ->orderDesc($posts->query()->expr('id'));
+                    ->orderDesc($posts->selectQuery()->expr('modified'))
+                    ->orderDesc($posts->selectQuery()->expr('id'));
             },
             new PaginationResult(
                 [
@@ -1114,8 +1114,8 @@ class LampagerBehaviorTest extends TestCase
                     ->seekable()
                     ->exclusive()
                     ->limit(3)
-                    ->orderDesc($posts->query()->expr('modified'))
-                    ->orderDesc($posts->query()->expr('id'));
+                    ->orderDesc($posts->selectQuery()->expr('modified'))
+                    ->orderDesc($posts->selectQuery()->expr('id'));
             },
             new PaginationResult(
                 [
@@ -1151,8 +1151,8 @@ class LampagerBehaviorTest extends TestCase
                     ->backward()
                     ->seekable()
                     ->limit(3)
-                    ->orderDesc($posts->query()->expr('modified'))
-                    ->orderDesc($posts->query()->expr('id'))
+                    ->orderDesc($posts->selectQuery()->expr('modified'))
+                    ->orderDesc($posts->selectQuery()->expr('id'))
                     ->cursor([
                         'id' => 3,
                         'modified' => new FrozenTime('2017-01-01 10:00:00'),
@@ -1196,8 +1196,8 @@ class LampagerBehaviorTest extends TestCase
                     ->seekable()
                     ->exclusive()
                     ->limit(3)
-                    ->orderDesc($posts->query()->expr('modified'))
-                    ->orderDesc($posts->query()->expr('id'))
+                    ->orderDesc($posts->selectQuery()->expr('modified'))
+                    ->orderDesc($posts->selectQuery()->expr('id'))
                     ->cursor([
                         'id' => 3,
                         'modified' => new FrozenTime('2017-01-01 10:00:00'),

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -120,8 +120,8 @@ class QueryTest extends TestCase
         );
 
         $actual = $posts->lampager()
-            ->order([$posts->query()->expr('modified')])
-            ->order([$posts->query()->expr('id')])
+            ->order([$posts->selectQuery()->expr('modified')])
+            ->order([$posts->selectQuery()->expr('id')])
             ->limit(1)
             ->all();
 
@@ -155,7 +155,7 @@ class QueryTest extends TestCase
         $actual = $posts->lampager()
             ->orderAsc('modified')
             ->orderAsc('id')
-            ->limit($posts->query()->expr('1'))
+            ->limit($posts->selectQuery()->expr('1'))
             ->all();
 
         $this->assertJsonEquals($expected, $actual);
@@ -172,7 +172,7 @@ class QueryTest extends TestCase
         $posts->lampager()
             ->orderAsc('modified')
             ->orderAsc('id')
-            ->limit($posts->query()->expr('1 + 1'))
+            ->limit($posts->selectQuery()->expr('1 + 1'))
             ->all();
     }
 
@@ -236,14 +236,14 @@ class QueryTest extends TestCase
         $posts->lampager()
             ->orderAsc('modified')
             ->orderAsc('id')
-            ->union($posts->query()->select())
+            ->union($posts->selectQuery()->select())
             ->all();
     }
 
     public function testCall(): void
     {
         $this->expectException(\ErrorException::class);
-        $this->expectExceptionMessage('You must call `all()` first');
+        $this->expectExceptionMessage('Instead call `$query->all()->take(...)` instead.');
 
         /** @var LampagerBehavior&Table $posts */
         $posts = TableRegistry::getTableLocator()->get('Posts');


### PR DESCRIPTION
Since CakePHP 4.5 introduced backward-incompatible deprecations, lampager-cakephp will update its requirement to `cakephp/cakephp@^4.5` in the next release.