### PR TITLE
Support CakePHP 5.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,6 @@ jobs:
     strategy:
       matrix:
         php:
-          - 7.4
-          - 8.0
           - 8.1
           - 8.2
           - 8.3

--- a/README.md
+++ b/README.md
@@ -13,20 +13,21 @@ Rapid pagination without using OFFSET
 
 ## Requirements
 
-- PHP: ^7.4 || ^8.0
-- CakePHP: ^4.5
+- PHP: ^8.1
+- CakePHP: ^5.0
 - [lampager/lampager][]: ^0.4
 
 ### Note
 
 - For CakePHP 2.x, use [lampager/lampager-cakephp2][].
 - For CakePHP 3.x, use [lampager/lampager-cakephp v1.x][].
-- For CakePHP 4.x, use lampager/lampager-cakephp v2.x (this version).
+- For CakePHP 4.x, use [lampager/lampager-cakephp v2.x][].
+- For CakePHP 5.x, use lampager/lampager-cakephp v3.x (this version).
 
 ## Installing
 
 ```bash
-composer require lampager/lampager-cakephp:^2.0
+composer require lampager/lampager-cakephp:^3.0
 ```
 
 For SQLite users, see [SQLite](#sqlite) to configure.
@@ -64,8 +65,8 @@ are specific to Lampager such as `forward`, `seekable`, or `cursor`.
 ```php
 $query = $this->Posts
     ->where(['Posts.type' => 'public'])
-    ->orderDesc('created')
-    ->orderDesc('id')
+    ->orderByDesc('created')
+    ->orderByDesc('id')
     ->limit(10);
 
 $posts = $this->paginate($query, [
@@ -121,9 +122,10 @@ $latest = $this->lampager()
     ->seekable()
     ->cursor($cursor)
     ->limit(10)
-    ->orderDesc('Posts.modified')
-    ->orderDesc('Posts.created')
-    ->orderDesc('Posts.id');
+    ->orderByDesc('Posts.modified')
+    ->orderByDesc('Posts.created')
+    ->orderByDesc('Posts.id')
+    ->paginate();
 
 foreach ($latest as $post) {
     /** @var \Cake\ORM\Entity $post */
@@ -144,9 +146,10 @@ $drafts = $this->lampager()
     ->seekable()
     ->cursor($cursor)
     ->limit(10)
-    ->orderDesc($this->selectQuery()->newExpr('modified'))
-    ->orderDesc($this->selectQuery()->newExpr('created'))
-    ->orderDesc($this->selectQuery()->newExpr('id'));
+    ->orderByDesc($this->selectQuery()->newExpr('modified'))
+    ->orderByDesc($this->selectQuery()->newExpr('created'))
+    ->orderByDesc($this->selectQuery()->newExpr('id'))
+    ->paginate();
 
 /** @var \Cake\ORM\Entity $sample */
 $sample = $drafts->sample();
@@ -159,20 +162,16 @@ $count = $drafts->count();
 
 See also: [lampager/lampager][].
 
-| Name                                                | Type  | Parent Class<br>Implemented Interface  | Description                                                                         |
-|:----------------------------------------------------|:------|:---------------------------------------|:------------------------------------------------------------------------------------|
-| Lampager\\Cake\\ORM\\`Query`                        | Class | Cake\\ORM\\`Query`                     | Fluent factory implementation for CakePHP                                           |
-| Lampager\\Cake\\Model\\Behavior\\`LampagerBehavior` | Class | Cake\\ORM\\`Behavior`                  | CakePHP behavior which returns Lampager\\Cake\\ORM\\`Query`                         |
-| Lampager\\Cake\\Datasource\\`Paginator`             | Class | Cake\\Datasource\\`Paginator`          | CakePHP paginatior which delegates to Lampager\\Cake\\ORM\\`Query`                  |
-| Lampager\\Cake\\`Paginator`                         | Class | Lampager\\`Paginator`                  | Paginator implementation for CakePHP                                                |
-| Lampager\\Cake\\`ArrayProcessor`                    | Class | Lampager\\`ArrayProcessor`             | Processor implementation for CakePHP                                                |
-| Lampager\\Cake\\`PaginationResult`                  | Class | Cake\\Datasource\\`ResultSetInterface` | PaginationResult implementation for CakePHP                                         |
-| Lampager\\Cake\\Database\\`SqliteCompiler`          | Class | Cake\\Database\\`SqliteCompiler`       | Query compiler implementation for SQLite                                            |
-| Lampager\\Cake\\Database\\Driver\\`Sqlite`          | Class | Cake\\Database\\Driver\\`Sqlite`       | Driver implementation which delegates to Lampager\\Cake\\Database\\`SqliteCompiler` |
-
-Note that `\Lampager\Cake\PaginationResult` does not extend
-`\Lampager\PaginationResult` as it conflicts with
-`\Cake\Datasource\ResultSetInterface`.
+| Name                                                | Type  | Parent Class<br>Implemented Interface                                          | Description                                                                         |
+|:----------------------------------------------------|:------|:-------------------------------------------------------------------------------|:------------------------------------------------------------------------------------|
+| Lampager\\Cake\\ORM\\`Query`                        | Class | Cake\\ORM\\`Query`                                                             | Fluent factory implementation for CakePHP                                           |
+| Lampager\\Cake\\Model\\Behavior\\`LampagerBehavior` | Class | Cake\\ORM\\`Behavior`                                                          | CakePHP behavior which returns Lampager\\Cake\\ORM\\`Query`                         |
+| Lampager\\Cake\\Datasource\\`Paginator`             | Class | Cake\\Datasource\\`Paginator`                                                  | CakePHP paginatior which delegates to Lampager\\Cake\\ORM\\`Query`                  |
+| Lampager\\Cake\\`Paginator`                         | Class | Lampager\\`Paginator`                                                          | Paginator implementation for CakePHP                                                |
+| Lampager\\Cake\\`ArrayProcessor`                    | Class | Lampager\\`ArrayProcessor`                                                     | Processor implementation for CakePHP                                                |
+| Lampager\\Cake\\`PaginationResult`                  | Class | Lampager\\`PaginationResult`<br>Cake\\Datasource\\Paging\\`PaginatedInterface` | PaginationResult implementation for CakePHP                                         |
+| Lampager\\Cake\\Database\\`SqliteCompiler`          | Class | Cake\\Database\\`SqliteCompiler`                                               | Query compiler implementation for SQLite                                            |
+| Lampager\\Cake\\Database\\Driver\\`Sqlite`          | Class | Cake\\Database\\Driver\\`Sqlite`                                               | Driver implementation which delegates to Lampager\\Cake\\Database\\`SqliteCompiler` |
 
 ## API
 
@@ -192,8 +191,8 @@ Create a new paginator instance. These methods are not intended to be directly
 used in your code.
 
 ```php
-static Paginator::create(\Cake\ORM\Query $builder): static
-Paginator::__construct(\Cake\ORM\Query $builder)
+static Paginator::create(\Cake\ORM\Query\SelectQuery $builder): static
+Paginator::__construct(\Cake\ORM\Query\SelectQuery $builder)
 ```
 
 ### Paginator::transform()
@@ -201,7 +200,7 @@ Paginator::__construct(\Cake\ORM\Query $builder)
 Transform a Lampager query into a CakePHP query.
 
 ```php
-Paginator::transform(\Lampager\Query $query): \Cake\ORM\Query
+Paginator::transform(\Lampager\Query $query): \Cake\ORM\Query\SelectQuery
 ```
 
 ### Paginator::build()
@@ -209,7 +208,7 @@ Paginator::transform(\Lampager\Query $query): \Cake\ORM\Query
 Perform configure + transform.
 
 ```php
-Paginator::build(\Lampager\Contracts\Cursor|array $cursor = []): \Cake\ORM\Query
+Paginator::build(\Lampager\Contracts\Cursor|array $cursor = []): \Cake\ORM\Query\SelectQuery
 ```
 
 ### Paginator::paginate()
@@ -270,8 +269,7 @@ object(Lampager\Cake\PaginationResult)#1 (6) {
 ### PaginationResult::\_\_call()
 
 `\Lampager\Cake\PaginationResult` implements
-`\Cake\Datasource\ResultSetInterface`. For how to make the best use of the
-`PaginationResult`, please refer to the Cookbook: [Working with Result Sets][].
+`\Cake\Datasource\Paging\PaginatedInterface`.
 
 ## Examples
 
@@ -303,8 +301,8 @@ class PostsController extends AppController
         // Query expression can be passed to PaginatorComponent::paginate() as normal
         $query = $this->Posts
             ->where(['Posts.type' => 'public'])
-            ->orderDesc('created')
-            ->orderDesc('id')
+            ->orderByDesc('created')
+            ->orderByDesc('id')
             ->limit(15);
 
         /** @var \Lampager\Cake\PaginationResult<\Cake\ORM\Entity> $posts */
@@ -415,6 +413,6 @@ return [
 
 [lampager/lampager]:              https://github.com/lampager/lampager
 [lampager/lampager-cakephp v1.x]: https://github.com/lampager/lampager-cakephp/tree/v1.x
+[lampager/lampager-cakephp v2.x]: https://github.com/lampager/lampager-cakephp/tree/v2.x
 [lampager/lampager-cakephp2]:     https://github.com/lampager/lampager-cakephp2
-[Pagination]:                     https://book.cakephp.org/4/en/controllers/pagination.html
-[Working with Result Sets]:       https://book.cakephp.org/4/en/orm/retrieving-data-and-resultsets.html#working-with-result-sets
+[Pagination]:                     https://book.cakephp.org/5/en/controllers/pagination.html

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "lampager/lampager-cakephp",
-    "description": "Rapid pagination for CakePHP 4",
+    "description": "Rapid pagination for CakePHP 5",
     "type": "cakephp-plugin",
     "license": "MIT",
     "authors": [
@@ -21,12 +21,12 @@
         }
     },
     "require": {
-        "php": "^7.4 || ^8.0",
-        "cakephp/cakephp": "^4.5",
+        "php": "^8.1",
+        "cakephp/cakephp": "^5.0",
         "lampager/lampager": "^0.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0 || ^9.0",
+        "phpunit/phpunit": "^10.1",
         "nilportugues/sql-query-formatter": "^1.2"
     },
     "scripts": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,10 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd"
          colors="true"
          processIsolation="false"
          stopOnFailure="false"
          bootstrap="tests/bootstrap.php">
+    <source>
+        <include>
+            <directory suffix=".php">src/</directory>
+        </include>
+    </source>
+
     <testsuites>
         <testsuite name="Lampager CakePHP Test Suite">
             <directory>tests/TestCase/</directory>
@@ -12,13 +18,10 @@
     </testsuites>
 
     <extensions>
-        <extension class="\Cake\TestSuite\Fixture\PHPUnitExtension" />
+        <bootstrap class="\Cake\TestSuite\Fixture\Extension\PHPUnitExtension" />
     </extensions>
 
     <coverage>
-        <include>
-            <directory suffix=".php">src/</directory>
-        </include>
         <report>
             <clover outputFile="build/logs/clover.xml" />
             <html outputDirectory="build/coverage" />

--- a/src/ArrayProcessor.php
+++ b/src/ArrayProcessor.php
@@ -16,7 +16,9 @@ class ArrayProcessor extends BaseArrayProcessor
      */
     protected function defaultFormat($rows, array $meta, LampagerQuery $query)
     {
-        return new PaginationResult($rows, $meta);
+        return new PaginationResult($rows, $meta + [
+            'limit' => $query->limit(),
+        ]);
     }
 
     /**

--- a/src/Model/Behavior/LampagerBehavior.php
+++ b/src/Model/Behavior/LampagerBehavior.php
@@ -5,16 +5,12 @@ declare(strict_types=1);
 namespace Lampager\Cake\Model\Behavior;
 
 use Cake\ORM\Behavior;
-use Cake\ORM\Table;
 use Lampager\Cake\ORM\Query;
 
 class LampagerBehavior extends Behavior
 {
     public function lampager(): Query
     {
-        $query = new Query($this->table()->getConnection(), $this->table());
-        $query->select();
-
-        return $query;
+        return new Query($this->table());
     }
 }

--- a/tests/Fixture/PostsFixture.php
+++ b/tests/Fixture/PostsFixture.php
@@ -8,7 +8,7 @@ use Cake\TestSuite\Fixture\TestFixture;
 
 class PostsFixture extends TestFixture
 {
-    public $records = [
+    public array $records = [
         ['id' => 1, 'modified' => '2017-01-01 10:00:00'],
         ['id' => 3, 'modified' => '2017-01-01 10:00:00'],
         ['id' => 5, 'modified' => '2017-01-01 10:00:00'],

--- a/tests/TestCase/Database/SqliteCompilerTest.php
+++ b/tests/TestCase/Database/SqliteCompilerTest.php
@@ -10,7 +10,7 @@ use Lampager\Cake\Test\TestCase\TestCase;
 
 class SqliteCompilerTest extends TestCase
 {
-    public $fixtures = [
+    public array $fixtures = [
         'plugin.Lampager\\Cake.Posts',
     ];
 

--- a/tests/TestCase/Model/ArrayProcessorTest.php
+++ b/tests/TestCase/Model/ArrayProcessorTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Lampager\Cake\Test\TestCase\Model;
 
-use Cake\I18n\FrozenTime;
+use Cake\I18n\DateTime;
 use Cake\ORM\Entity;
 use Cake\ORM\Table;
 use Generator;
@@ -42,7 +42,7 @@ class ArrayProcessorTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function processProvider(): Generator
+    public static function processProvider(): Generator
     {
         yield 'Option has prefix but entity does not have prefix' => [
             [
@@ -56,55 +56,56 @@ class ArrayProcessorTest extends TestCase
             ],
             [
                 'Posts.id' => 3,
-                'Posts.modified' => new FrozenTime('2017-01-01 10:00:00'),
+                'Posts.modified' => new DateTime('2017-01-01 10:00:00'),
             ],
             [
                 new Entity([
                     'id' => 1,
-                    'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                    'modified' => new DateTime('2017-01-01 10:00:00'),
                 ]),
                 new Entity([
                     'id' => 3,
-                    'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                    'modified' => new DateTime('2017-01-01 10:00:00'),
                 ]),
                 new Entity([
                     'id' => 5,
-                    'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                    'modified' => new DateTime('2017-01-01 10:00:00'),
                 ]),
                 new Entity([
                     'id' => 2,
-                    'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                    'modified' => new DateTime('2017-01-01 11:00:00'),
                 ]),
                 new Entity([
                     'id' => 4,
-                    'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                    'modified' => new DateTime('2017-01-01 11:00:00'),
                 ]),
             ],
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 2,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                 ], [
                     'hasPrevious' => true,
                     'previousCursor' => [
                         'Posts.id' => 1,
-                        'Posts.modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'Posts.modified' => new DateTime('2017-01-01 10:00:00'),
                     ],
                     'hasNext' => true,
                     'nextCursor' => [
                         'Posts.id' => 4,
-                        'Posts.modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'Posts.modified' => new DateTime('2017-01-01 11:00:00'),
                     ],
+                    'limit' => 3,
                 ]
             ),
         ];
@@ -121,55 +122,56 @@ class ArrayProcessorTest extends TestCase
             ],
             [
                 'id' => 3,
-                'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                'modified' => new DateTime('2017-01-01 10:00:00'),
             ],
             [
                 new Entity([
                     'id' => 1,
-                    'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                    'modified' => new DateTime('2017-01-01 10:00:00'),
                 ]),
                 new Entity([
                     'id' => 3,
-                    'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                    'modified' => new DateTime('2017-01-01 10:00:00'),
                 ]),
                 new Entity([
                     'id' => 5,
-                    'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                    'modified' => new DateTime('2017-01-01 10:00:00'),
                 ]),
                 new Entity([
                     'id' => 2,
-                    'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                    'modified' => new DateTime('2017-01-01 11:00:00'),
                 ]),
                 new Entity([
                     'id' => 4,
-                    'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                    'modified' => new DateTime('2017-01-01 11:00:00'),
                 ]),
             ],
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 2,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                 ], [
                     'hasPrevious' => true,
                     'previousCursor' => [
                         'id' => 1,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ],
                     'hasNext' => true,
                     'nextCursor' => [
                         'id' => 4,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ],
+                    'limit' => 3,
                 ]
             ),
         ];
@@ -186,55 +188,56 @@ class ArrayProcessorTest extends TestCase
             ],
             [
                 'id' => 3,
-                'Posts.modified' => new FrozenTime('2017-01-01 10:00:00'),
+                'Posts.modified' => new DateTime('2017-01-01 10:00:00'),
             ],
             [
                 new Entity([
                     'id' => 1,
-                    'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                    'modified' => new DateTime('2017-01-01 10:00:00'),
                 ]),
                 new Entity([
                     'id' => 3,
-                    'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                    'modified' => new DateTime('2017-01-01 10:00:00'),
                 ]),
                 new Entity([
                     'id' => 5,
-                    'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                    'modified' => new DateTime('2017-01-01 10:00:00'),
                 ]),
                 new Entity([
                     'id' => 2,
-                    'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                    'modified' => new DateTime('2017-01-01 11:00:00'),
                 ]),
                 new Entity([
                     'id' => 4,
-                    'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                    'modified' => new DateTime('2017-01-01 11:00:00'),
                 ]),
             ],
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 2,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                 ], [
                     'hasPrevious' => true,
                     'previousCursor' => [
                         'id' => 1,
-                        'Posts.modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'Posts.modified' => new DateTime('2017-01-01 10:00:00'),
                     ],
                     'hasNext' => true,
                     'nextCursor' => [
                         'id' => 4,
-                        'Posts.modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'Posts.modified' => new DateTime('2017-01-01 11:00:00'),
                     ],
+                    'limit' => 3,
                 ]
             ),
         ];

--- a/tests/TestCase/Model/Behavior/LampagerBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/LampagerBehaviorTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Lampager\Cake\Test\TestCase\Model\Behavior;
 
-use Cake\I18n\FrozenTime;
+use Cake\I18n\DateTime;
 use Cake\ORM\Entity;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
@@ -16,7 +16,7 @@ use Lampager\PaginationResult;
 
 class LampagerBehaviorTest extends TestCase
 {
-    public $fixtures = [
+    public array $fixtures = [
         'plugin.Lampager\\Cake.Posts',
     ];
 
@@ -32,10 +32,10 @@ class LampagerBehaviorTest extends TestCase
 
         /** @var Query $query */
         $query = $factory($posts);
-        $this->assertJsonEquals($expected, $query->all());
+        $this->assertJsonEquals($expected, $query->paginate());
     }
 
-    public function valueProvider(): Generator
+    public static function valueProvider(): Generator
     {
         yield 'Ascending forward start inclusive' => [
             function (Table $posts) {
@@ -44,22 +44,22 @@ class LampagerBehaviorTest extends TestCase
                     ->forward()
                     ->seekable()
                     ->limit(3)
-                    ->orderAsc('modified')
-                    ->orderAsc('id');
+                    ->orderByAsc('modified')
+                    ->orderByAsc('id');
             },
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 1,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                 ],
                 [
@@ -68,7 +68,7 @@ class LampagerBehaviorTest extends TestCase
                     'hasNext' => true,
                     'nextCursor' => [
                         'id' => 2,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ],
                 ]
             ),
@@ -82,22 +82,22 @@ class LampagerBehaviorTest extends TestCase
                     ->seekable()
                     ->exclusive()
                     ->limit(3)
-                    ->orderAsc('modified')
-                    ->orderAsc('id');
+                    ->orderByAsc('modified')
+                    ->orderByAsc('id');
             },
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 1,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                 ],
                 [
@@ -106,7 +106,7 @@ class LampagerBehaviorTest extends TestCase
                     'hasNext' => true,
                     'nextCursor' => [
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ],
                 ]
             ),
@@ -119,38 +119,38 @@ class LampagerBehaviorTest extends TestCase
                     ->forward()
                     ->seekable()
                     ->limit(3)
-                    ->orderAsc('modified')
-                    ->orderAsc('id')
+                    ->orderByAsc('modified')
+                    ->orderByAsc('id')
                     ->cursor([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]);
             },
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 2,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                 ],
                 [
                     'hasPrevious' => true,
                     'previousCursor' => [
                         'id' => 1,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ],
                     'hasNext' => true,
                     'nextCursor' => [
                         'id' => 4,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ],
                 ]
             ),
@@ -164,33 +164,33 @@ class LampagerBehaviorTest extends TestCase
                     ->seekable()
                     ->exclusive()
                     ->limit(3)
-                    ->orderAsc('modified')
-                    ->orderAsc('id')
+                    ->orderByAsc('modified')
+                    ->orderByAsc('id')
                     ->cursor([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]);
             },
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 2,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                     new Entity([
                         'id' => 4,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                 ],
                 [
                     'hasPrevious' => true,
                     'previousCursor' => [
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ],
                     'hasNext' => false,
                     'nextCursor' => null,
@@ -205,29 +205,29 @@ class LampagerBehaviorTest extends TestCase
                     ->backward()
                     ->seekable()
                     ->limit(3)
-                    ->orderAsc('modified')
-                    ->orderAsc('id');
+                    ->orderByAsc('modified')
+                    ->orderByAsc('id');
             },
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 2,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                     new Entity([
                         'id' => 4,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                 ],
                 [
                     'hasPrevious' => true,
                     'previousCursor' => [
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ],
                     'hasNext' => null,
                     'nextCursor' => null,
@@ -243,29 +243,29 @@ class LampagerBehaviorTest extends TestCase
                     ->seekable()
                     ->exclusive()
                     ->limit(3)
-                    ->orderAsc('modified')
-                    ->orderAsc('id');
+                    ->orderByAsc('modified')
+                    ->orderByAsc('id');
             },
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 2,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                     new Entity([
                         'id' => 4,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                 ],
                 [
                     'hasPrevious' => true,
                     'previousCursor' => [
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ],
                     'hasNext' => null,
                     'nextCursor' => null,
@@ -280,22 +280,22 @@ class LampagerBehaviorTest extends TestCase
                     ->backward()
                     ->seekable()
                     ->limit(3)
-                    ->orderAsc('modified')
-                    ->orderAsc('id')
+                    ->orderByAsc('modified')
+                    ->orderByAsc('id')
                     ->cursor([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]);
             },
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 1,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                 ],
                 [
@@ -304,7 +304,7 @@ class LampagerBehaviorTest extends TestCase
                     'hasNext' => true,
                     'nextCursor' => [
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ],
                 ]
             ),
@@ -318,18 +318,18 @@ class LampagerBehaviorTest extends TestCase
                     ->seekable()
                     ->exclusive()
                     ->limit(3)
-                    ->orderAsc('modified')
-                    ->orderAsc('id')
+                    ->orderByAsc('modified')
+                    ->orderByAsc('id')
                     ->cursor([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]);
             },
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 1,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                 ],
                 [
@@ -338,7 +338,7 @@ class LampagerBehaviorTest extends TestCase
                     'hasNext' => true,
                     'nextCursor' => [
                         'id' => 1,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ],
                 ]
             ),
@@ -351,22 +351,22 @@ class LampagerBehaviorTest extends TestCase
                     ->forward()
                     ->seekable()
                     ->limit(3)
-                    ->orderDesc('modified')
-                    ->orderDesc('id');
+                    ->orderByDesc('modified')
+                    ->orderByDesc('id');
             },
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 4,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                     new Entity([
                         'id' => 2,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                     new Entity([
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                 ],
                 [
@@ -375,7 +375,7 @@ class LampagerBehaviorTest extends TestCase
                     'hasNext' => true,
                     'nextCursor' => [
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ],
                 ]
             ),
@@ -389,22 +389,22 @@ class LampagerBehaviorTest extends TestCase
                     ->seekable()
                     ->exclusive()
                     ->limit(3)
-                    ->orderDesc('modified')
-                    ->orderDesc('id');
+                    ->orderByDesc('modified')
+                    ->orderByDesc('id');
             },
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 4,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                     new Entity([
                         'id' => 2,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                     new Entity([
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                 ],
                 [
@@ -413,7 +413,7 @@ class LampagerBehaviorTest extends TestCase
                     'hasNext' => true,
                     'nextCursor' => [
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ],
                 ]
             ),
@@ -426,29 +426,29 @@ class LampagerBehaviorTest extends TestCase
                     ->forward()
                     ->seekable()
                     ->limit(3)
-                    ->orderDesc('modified')
-                    ->orderDesc('id')
+                    ->orderByDesc('modified')
+                    ->orderByDesc('id')
                     ->cursor([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]);
             },
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 1,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                 ],
                 [
                     'hasPrevious' => true,
                     'previousCursor' => [
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ],
                     'hasNext' => false,
                     'nextCursor' => null,
@@ -464,25 +464,25 @@ class LampagerBehaviorTest extends TestCase
                     ->seekable()
                     ->exclusive()
                     ->limit(3)
-                    ->orderDesc('modified')
-                    ->orderDesc('id')
+                    ->orderByDesc('modified')
+                    ->orderByDesc('id')
                     ->cursor([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]);
             },
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 1,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                 ],
                 [
                     'hasPrevious' => true,
                     'previousCursor' => [
                         'id' => 1,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ],
                     'hasNext' => false,
                     'nextCursor' => null,
@@ -497,29 +497,29 @@ class LampagerBehaviorTest extends TestCase
                     ->backward()
                     ->seekable()
                     ->limit(3)
-                    ->orderDesc('modified')
-                    ->orderDesc('id');
+                    ->orderByDesc('modified')
+                    ->orderByDesc('id');
             },
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 1,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                 ],
                 [
                     'hasPrevious' => true,
                     'previousCursor' => [
                         'id' => 2,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ],
                     'hasNext' => null,
                     'nextCursor' => null,
@@ -535,29 +535,29 @@ class LampagerBehaviorTest extends TestCase
                     ->seekable()
                     ->exclusive()
                     ->limit(3)
-                    ->orderDesc('modified')
-                    ->orderDesc('id');
+                    ->orderByDesc('modified')
+                    ->orderByDesc('id');
             },
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 1,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                 ],
                 [
                     'hasPrevious' => true,
                     'previousCursor' => [
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ],
                     'hasNext' => null,
                     'nextCursor' => null,
@@ -572,38 +572,38 @@ class LampagerBehaviorTest extends TestCase
                     ->backward()
                     ->seekable()
                     ->limit(3)
-                    ->orderDesc('modified')
-                    ->orderDesc('id')
+                    ->orderByDesc('modified')
+                    ->orderByDesc('id')
                     ->cursor([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]);
             },
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 2,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                     new Entity([
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                 ],
                 [
                     'hasPrevious' => true,
                     'previousCursor' => [
                         'id' => 4,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ],
                     'hasNext' => true,
                     'nextCursor' => [
                         'id' => 1,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ],
                 ]
             ),
@@ -617,26 +617,26 @@ class LampagerBehaviorTest extends TestCase
                     ->seekable()
                     ->exclusive()
                     ->limit(3)
-                    ->orderDesc('modified')
-                    ->orderDesc('id')
+                    ->orderByDesc('modified')
+                    ->orderByDesc('id')
                     ->cursor([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]);
             },
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 4,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                     new Entity([
                         'id' => 2,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                     new Entity([
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                 ],
                 [
@@ -645,14 +645,14 @@ class LampagerBehaviorTest extends TestCase
                     'hasNext' => true,
                     'nextCursor' => [
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ],
                 ]
             ),
         ];
     }
 
-    public function queryExpressionProvider(): Generator
+    public static function queryExpressionProvider(): Generator
     {
         yield 'Ascending forward start inclusive with QueryExpression' => [
             function (Table $posts) {
@@ -661,22 +661,22 @@ class LampagerBehaviorTest extends TestCase
                     ->forward()
                     ->seekable()
                     ->limit(3)
-                    ->orderAsc($posts->selectQuery()->expr('modified'))
-                    ->orderAsc($posts->selectQuery()->expr('id'));
+                    ->orderByAsc($posts->selectQuery()->expr('modified'))
+                    ->orderByAsc($posts->selectQuery()->expr('id'));
             },
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 1,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                 ],
                 [
@@ -685,7 +685,7 @@ class LampagerBehaviorTest extends TestCase
                     'hasNext' => true,
                     'nextCursor' => [
                         'id' => 2,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ],
                 ]
             ),
@@ -698,38 +698,38 @@ class LampagerBehaviorTest extends TestCase
                     ->forward()
                     ->seekable()
                     ->limit(3)
-                    ->orderAsc($posts->selectQuery()->expr('modified'))
-                    ->orderAsc($posts->selectQuery()->expr('id'))
+                    ->orderByAsc($posts->selectQuery()->expr('modified'))
+                    ->orderByAsc($posts->selectQuery()->expr('id'))
                     ->cursor([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]);
             },
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 2,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                 ],
                 [
                     'hasPrevious' => true,
                     'previousCursor' => [
                         'id' => 1,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ],
                     'hasNext' => true,
                     'nextCursor' => [
                         'id' => 4,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ],
                 ]
             ),
@@ -743,33 +743,33 @@ class LampagerBehaviorTest extends TestCase
                     ->seekable()
                     ->exclusive()
                     ->limit(3)
-                    ->orderAsc($posts->selectQuery()->expr('modified'))
-                    ->orderAsc($posts->selectQuery()->expr('id'))
+                    ->orderByAsc($posts->selectQuery()->expr('modified'))
+                    ->orderByAsc($posts->selectQuery()->expr('id'))
                     ->cursor([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]);
             },
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 2,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                     new Entity([
                         'id' => 4,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                 ],
                 [
                     'hasPrevious' => true,
                     'previousCursor' => [
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ],
                     'hasNext' => false,
                     'nextCursor' => null,
@@ -784,29 +784,29 @@ class LampagerBehaviorTest extends TestCase
                     ->backward()
                     ->seekable()
                     ->limit(3)
-                    ->orderAsc($posts->selectQuery()->expr('modified'))
-                    ->orderAsc($posts->selectQuery()->expr('id'));
+                    ->orderByAsc($posts->selectQuery()->expr('modified'))
+                    ->orderByAsc($posts->selectQuery()->expr('id'));
             },
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 2,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                     new Entity([
                         'id' => 4,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                 ],
                 [
                     'hasPrevious' => true,
                     'previousCursor' => [
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ],
                     'hasNext' => null,
                     'nextCursor' => null,
@@ -822,29 +822,29 @@ class LampagerBehaviorTest extends TestCase
                     ->seekable()
                     ->exclusive()
                     ->limit(3)
-                    ->orderAsc($posts->selectQuery()->expr('modified'))
-                    ->orderAsc($posts->selectQuery()->expr('id'));
+                    ->orderByAsc($posts->selectQuery()->expr('modified'))
+                    ->orderByAsc($posts->selectQuery()->expr('id'));
             },
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 2,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                     new Entity([
                         'id' => 4,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                 ],
                 [
                     'hasPrevious' => true,
                     'previousCursor' => [
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ],
                     'hasNext' => null,
                     'nextCursor' => null,
@@ -859,22 +859,22 @@ class LampagerBehaviorTest extends TestCase
                     ->backward()
                     ->seekable()
                     ->limit(3)
-                    ->orderAsc($posts->selectQuery()->expr('modified'))
-                    ->orderAsc($posts->selectQuery()->expr('id'))
+                    ->orderByAsc($posts->selectQuery()->expr('modified'))
+                    ->orderByAsc($posts->selectQuery()->expr('id'))
                     ->cursor([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]);
             },
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 1,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                 ],
                 [
@@ -883,7 +883,7 @@ class LampagerBehaviorTest extends TestCase
                     'hasNext' => true,
                     'nextCursor' => [
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ],
                 ]
             ),
@@ -897,18 +897,18 @@ class LampagerBehaviorTest extends TestCase
                     ->seekable()
                     ->exclusive()
                     ->limit(3)
-                    ->orderAsc($posts->selectQuery()->expr('modified'))
-                    ->orderAsc($posts->selectQuery()->expr('id'))
+                    ->orderByAsc($posts->selectQuery()->expr('modified'))
+                    ->orderByAsc($posts->selectQuery()->expr('id'))
                     ->cursor([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]);
             },
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 1,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                 ],
                 [
@@ -917,7 +917,7 @@ class LampagerBehaviorTest extends TestCase
                     'hasNext' => true,
                     'nextCursor' => [
                         'id' => 1,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ],
                 ]
             ),
@@ -930,22 +930,22 @@ class LampagerBehaviorTest extends TestCase
                     ->forward()
                     ->seekable()
                     ->limit(3)
-                    ->orderDesc($posts->selectQuery()->expr('modified'))
-                    ->orderDesc($posts->selectQuery()->expr('id'));
+                    ->orderByDesc($posts->selectQuery()->expr('modified'))
+                    ->orderByDesc($posts->selectQuery()->expr('id'));
             },
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 4,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                     new Entity([
                         'id' => 2,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                     new Entity([
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                 ],
                 [
@@ -954,7 +954,7 @@ class LampagerBehaviorTest extends TestCase
                     'hasNext' => true,
                     'nextCursor' => [
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ],
                 ]
             ),
@@ -968,22 +968,22 @@ class LampagerBehaviorTest extends TestCase
                     ->seekable()
                     ->exclusive()
                     ->limit(3)
-                    ->orderDesc($posts->selectQuery()->expr('modified'))
-                    ->orderDesc($posts->selectQuery()->expr('id'));
+                    ->orderByDesc($posts->selectQuery()->expr('modified'))
+                    ->orderByDesc($posts->selectQuery()->expr('id'));
             },
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 4,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                     new Entity([
                         'id' => 2,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                     new Entity([
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                 ],
                 [
@@ -992,7 +992,7 @@ class LampagerBehaviorTest extends TestCase
                     'hasNext' => true,
                     'nextCursor' => [
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ],
                 ]
             ),
@@ -1005,29 +1005,29 @@ class LampagerBehaviorTest extends TestCase
                     ->forward()
                     ->seekable()
                     ->limit(3)
-                    ->orderDesc($posts->selectQuery()->expr('modified'))
-                    ->orderDesc($posts->selectQuery()->expr('id'))
+                    ->orderByDesc($posts->selectQuery()->expr('modified'))
+                    ->orderByDesc($posts->selectQuery()->expr('id'))
                     ->cursor([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]);
             },
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 1,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                 ],
                 [
                     'hasPrevious' => true,
                     'previousCursor' => [
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ],
                     'hasNext' => false,
                     'nextCursor' => null,
@@ -1043,25 +1043,25 @@ class LampagerBehaviorTest extends TestCase
                     ->seekable()
                     ->exclusive()
                     ->limit(3)
-                    ->orderDesc($posts->selectQuery()->expr('modified'))
-                    ->orderDesc($posts->selectQuery()->expr('id'))
+                    ->orderByDesc($posts->selectQuery()->expr('modified'))
+                    ->orderByDesc($posts->selectQuery()->expr('id'))
                     ->cursor([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]);
             },
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 1,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                 ],
                 [
                     'hasPrevious' => true,
                     'previousCursor' => [
                         'id' => 1,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ],
                     'hasNext' => false,
                     'nextCursor' => null,
@@ -1076,29 +1076,29 @@ class LampagerBehaviorTest extends TestCase
                     ->backward()
                     ->seekable()
                     ->limit(3)
-                    ->orderDesc($posts->selectQuery()->expr('modified'))
-                    ->orderDesc($posts->selectQuery()->expr('id'));
+                    ->orderByDesc($posts->selectQuery()->expr('modified'))
+                    ->orderByDesc($posts->selectQuery()->expr('id'));
             },
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 1,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                 ],
                 [
                     'hasPrevious' => true,
                     'previousCursor' => [
                         'id' => 2,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ],
                     'hasNext' => null,
                     'nextCursor' => null,
@@ -1114,29 +1114,29 @@ class LampagerBehaviorTest extends TestCase
                     ->seekable()
                     ->exclusive()
                     ->limit(3)
-                    ->orderDesc($posts->selectQuery()->expr('modified'))
-                    ->orderDesc($posts->selectQuery()->expr('id'));
+                    ->orderByDesc($posts->selectQuery()->expr('modified'))
+                    ->orderByDesc($posts->selectQuery()->expr('id'));
             },
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 1,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                 ],
                 [
                     'hasPrevious' => true,
                     'previousCursor' => [
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ],
                     'hasNext' => null,
                     'nextCursor' => null,
@@ -1151,38 +1151,38 @@ class LampagerBehaviorTest extends TestCase
                     ->backward()
                     ->seekable()
                     ->limit(3)
-                    ->orderDesc($posts->selectQuery()->expr('modified'))
-                    ->orderDesc($posts->selectQuery()->expr('id'))
+                    ->orderByDesc($posts->selectQuery()->expr('modified'))
+                    ->orderByDesc($posts->selectQuery()->expr('id'))
                     ->cursor([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]);
             },
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 2,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                     new Entity([
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                 ],
                 [
                     'hasPrevious' => true,
                     'previousCursor' => [
                         'id' => 4,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ],
                     'hasNext' => true,
                     'nextCursor' => [
                         'id' => 1,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ],
                 ]
             ),
@@ -1196,26 +1196,26 @@ class LampagerBehaviorTest extends TestCase
                     ->seekable()
                     ->exclusive()
                     ->limit(3)
-                    ->orderDesc($posts->selectQuery()->expr('modified'))
-                    ->orderDesc($posts->selectQuery()->expr('id'))
+                    ->orderByDesc($posts->selectQuery()->expr('modified'))
+                    ->orderByDesc($posts->selectQuery()->expr('id'))
                     ->cursor([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]);
             },
             new PaginationResult(
                 [
                     new Entity([
                         'id' => 4,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                     new Entity([
                         'id' => 2,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                     new Entity([
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                 ],
                 [
@@ -1224,7 +1224,7 @@ class LampagerBehaviorTest extends TestCase
                     'hasNext' => true,
                     'nextCursor' => [
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ],
                 ]
             ),

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Lampager\Cake\Test\TestCase\ORM;
 
 use Cake\Database\Expression\OrderClauseExpression;
-use Cake\I18n\FrozenTime;
+use Cake\I18n\DateTime;
 use Cake\ORM\Entity;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
@@ -23,7 +23,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 class QueryTest extends TestCase
 {
-    public $fixtures = [
+    public array $fixtures = [
         'plugin.Lampager\\Cake.Posts',
     ];
 
@@ -49,7 +49,7 @@ class QueryTest extends TestCase
     /**
      * @dataProvider orderProvider
      */
-    public function testOrder(callable $factory, PaginationResult $expected): void
+    public function testorderBy(callable $factory, PaginationResult $expected): void
     {
         /** @var LampagerBehavior&Table $posts */
         $posts = TableRegistry::getTableLocator()->get('Posts');
@@ -57,7 +57,7 @@ class QueryTest extends TestCase
 
         /** @var Query $query */
         $query = $factory($posts);
-        $this->assertJsonEquals($expected, $query->all());
+        $this->assertJsonEquals($expected, $query->paginate());
     }
 
     /**
@@ -74,8 +74,8 @@ class QueryTest extends TestCase
 
         /** @var Query $query */
         $query = $factory($posts);
-        $query->order([], true);
-        $query->all();
+        $query->orderBy([], true);
+        $query->paginate();
     }
 
     public function testOrderIllegal(): void
@@ -91,8 +91,8 @@ class QueryTest extends TestCase
         $posts = TableRegistry::getTableLocator()->get('Posts');
         $posts->addBehavior(LampagerBehavior::class);
         $posts->lampager()
-            ->order([$expression])
-            ->all();
+            ->orderBy([$expression])
+            ->paginate();
     }
 
     public function testOrderQueryExpression(): void
@@ -105,7 +105,7 @@ class QueryTest extends TestCase
             [
                 new Entity([
                     'id' => 1,
-                    'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                    'modified' => new DateTime('2017-01-01 10:00:00'),
                 ]),
             ],
             [
@@ -114,16 +114,16 @@ class QueryTest extends TestCase
                 'hasNext' => true,
                 'nextCursor' => [
                     'id' => 3,
-                    'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                    'modified' => new DateTime('2017-01-01 10:00:00'),
                 ],
             ]
         );
 
         $actual = $posts->lampager()
-            ->order([$posts->selectQuery()->expr('modified')])
-            ->order([$posts->selectQuery()->expr('id')])
+            ->orderBy([$posts->selectQuery()->expr('modified')])
+            ->orderBy([$posts->selectQuery()->expr('id')])
             ->limit(1)
-            ->all();
+            ->paginate();
 
         $this->assertJsonEquals($expected, $actual);
     }
@@ -138,7 +138,7 @@ class QueryTest extends TestCase
             [
                 new Entity([
                     'id' => 1,
-                    'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                    'modified' => new DateTime('2017-01-01 10:00:00'),
                 ]),
             ],
             [
@@ -147,16 +147,16 @@ class QueryTest extends TestCase
                 'hasNext' => true,
                 'nextCursor' => [
                     'id' => 3,
-                    'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                    'modified' => new DateTime('2017-01-01 10:00:00'),
                 ],
             ]
         );
 
         $actual = $posts->lampager()
-            ->orderAsc('modified')
-            ->orderAsc('id')
+            ->orderByAsc('modified')
+            ->orderByAsc('id')
             ->limit($posts->selectQuery()->expr('1'))
-            ->all();
+            ->paginate();
 
         $this->assertJsonEquals($expected, $actual);
     }
@@ -170,10 +170,10 @@ class QueryTest extends TestCase
         $posts = TableRegistry::getTableLocator()->get('Posts');
         $posts->addBehavior(LampagerBehavior::class);
         $posts->lampager()
-            ->orderAsc('modified')
-            ->orderAsc('id')
+            ->orderByAsc('modified')
+            ->orderByAsc('id')
             ->limit($posts->selectQuery()->expr('1 + 1'))
-            ->all();
+            ->paginate();
     }
 
     public function testWhere(): void
@@ -186,7 +186,7 @@ class QueryTest extends TestCase
             [
                 new Entity([
                     'id' => 3,
-                    'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                    'modified' => new DateTime('2017-01-01 10:00:00'),
                 ]),
             ],
             [
@@ -195,17 +195,17 @@ class QueryTest extends TestCase
                 'hasNext' => true,
                 'nextCursor' => [
                     'id' => 5,
-                    'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                    'modified' => new DateTime('2017-01-01 10:00:00'),
                 ],
             ]
         );
 
         $actual = $posts->lampager()
             ->where(['id >' => 1])
-            ->orderAsc('modified')
-            ->orderAsc('id')
+            ->orderByAsc('modified')
+            ->orderByAsc('id')
             ->limit(1)
-            ->all();
+            ->paginate();
 
         $this->assertJsonEquals($expected, $actual);
     }
@@ -219,10 +219,10 @@ class QueryTest extends TestCase
         $posts = TableRegistry::getTableLocator()->get('Posts');
         $posts->addBehavior(LampagerBehavior::class);
         $posts->lampager()
-            ->orderAsc('modified')
-            ->orderAsc('id')
-            ->group('modified')
-            ->all();
+            ->orderByAsc('modified')
+            ->orderByAsc('id')
+            ->groupBy('modified')
+            ->paginate();
     }
 
     public function testUnion(): void
@@ -234,22 +234,22 @@ class QueryTest extends TestCase
         $posts = TableRegistry::getTableLocator()->get('Posts');
         $posts->addBehavior(LampagerBehavior::class);
         $posts->lampager()
-            ->orderAsc('modified')
-            ->orderAsc('id')
+            ->orderByAsc('modified')
+            ->orderByAsc('id')
             ->union($posts->selectQuery()->select())
-            ->all();
+            ->paginate();
     }
 
     public function testCall(): void
     {
-        $this->expectException(\ErrorException::class);
-        $this->expectExceptionMessage('Instead call `$query->all()->take(...)` instead.');
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Method Lampager\Cake\ORM\Query::take does not exist');
 
         /** @var LampagerBehavior&Table $posts */
         $posts = TableRegistry::getTableLocator()->get('Posts');
         $posts->addBehavior(LampagerBehavior::class);
         $posts->lampager()
-            ->orderAsc('id')
+            ->orderByAsc('id')
             ->take();
     }
 
@@ -260,8 +260,8 @@ class QueryTest extends TestCase
         $posts->addBehavior(LampagerBehavior::class);
 
         $actual = $posts->lampager()
-            ->orderAsc('modified')
-            ->orderAsc('id')
+            ->orderByAsc('modified')
+            ->orderByAsc('id')
             ->limit(3)
             ->__debugInfo();
 
@@ -275,7 +275,6 @@ class QueryTest extends TestCase
         $this->assertArrayHasKey('decorators', $actual);
         $this->assertArrayHasKey('executed', $actual);
         $this->assertArrayHasKey('hydrate', $actual);
-        $this->assertArrayHasKey('buffered', $actual);
         $this->assertArrayHasKey('formatters', $actual);
         $this->assertArrayHasKey('mapReducers', $actual);
         $this->assertArrayHasKey('contain', $actual);
@@ -303,7 +302,6 @@ class QueryTest extends TestCase
         $this->assertArrayHasKey('decorators', $actual);
         $this->assertArrayHasKey('executed', $actual);
         $this->assertArrayHasKey('hydrate', $actual);
-        $this->assertArrayHasKey('buffered', $actual);
         $this->assertArrayHasKey('formatters', $actual);
         $this->assertArrayHasKey('mapReducers', $actual);
         $this->assertArrayHasKey('contain', $actual);
@@ -323,7 +321,7 @@ class QueryTest extends TestCase
         $this->assertSame($expected, $factory($posts));
     }
 
-    public function orderProvider(): Generator
+    public static function orderProvider(): Generator
     {
         yield 'Ascending and ascending' => [
             function (Table $posts) {
@@ -332,7 +330,7 @@ class QueryTest extends TestCase
                     ->forward()
                     ->seekable()
                     ->limit(3)
-                    ->order([
+                    ->orderBy([
                         'modified' => 'asc',
                         'id' => 'asc',
                     ]);
@@ -341,15 +339,15 @@ class QueryTest extends TestCase
                 [
                     new Entity([
                         'id' => 1,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                     new Entity([
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                 ],
                 [
@@ -358,7 +356,7 @@ class QueryTest extends TestCase
                     'hasNext' => true,
                     'nextCursor' => [
                         'id' => 2,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ],
                 ]
             ),
@@ -371,7 +369,7 @@ class QueryTest extends TestCase
                     ->forward()
                     ->seekable()
                     ->limit(3)
-                    ->order([
+                    ->orderBy([
                         'modified' => 'desc',
                         'id' => 'desc',
                     ]);
@@ -380,15 +378,15 @@ class QueryTest extends TestCase
                 [
                     new Entity([
                         'id' => 4,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                     new Entity([
                         'id' => 2,
-                        'modified' => new FrozenTime('2017-01-01 11:00:00'),
+                        'modified' => new DateTime('2017-01-01 11:00:00'),
                     ]),
                     new Entity([
                         'id' => 5,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ]),
                 ],
                 [
@@ -397,14 +395,14 @@ class QueryTest extends TestCase
                     'hasNext' => true,
                     'nextCursor' => [
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ],
                 ]
             ),
         ];
     }
 
-    public function countProvider(): Generator
+    public static function countProvider(): Generator
     {
         yield 'Ascending forward start inclusive' => [
             function (Table $posts) {
@@ -413,8 +411,8 @@ class QueryTest extends TestCase
                     ->forward()
                     ->seekable()
                     ->limit(3)
-                    ->orderAsc('modified')
-                    ->orderAsc('id')
+                    ->orderByAsc('modified')
+                    ->orderByAsc('id')
                     ->count();
             },
             3,
@@ -428,8 +426,8 @@ class QueryTest extends TestCase
                     ->seekable()
                     ->exclusive()
                     ->limit(3)
-                    ->orderAsc('modified')
-                    ->orderAsc('id')
+                    ->orderByAsc('modified')
+                    ->orderByAsc('id')
                     ->count();
             },
             3,
@@ -442,11 +440,11 @@ class QueryTest extends TestCase
                     ->forward()
                     ->seekable()
                     ->limit(3)
-                    ->orderAsc('modified')
-                    ->orderAsc('id')
+                    ->orderByAsc('modified')
+                    ->orderByAsc('id')
                     ->cursor([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ])
                     ->count();
             },
@@ -461,11 +459,11 @@ class QueryTest extends TestCase
                     ->seekable()
                     ->exclusive()
                     ->limit(3)
-                    ->orderAsc('modified')
-                    ->orderAsc('id')
+                    ->orderByAsc('modified')
+                    ->orderByAsc('id')
                     ->cursor([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ])
                     ->count();
             },
@@ -479,8 +477,8 @@ class QueryTest extends TestCase
                     ->backward()
                     ->seekable()
                     ->limit(3)
-                    ->orderAsc('modified')
-                    ->orderAsc('id')
+                    ->orderByAsc('modified')
+                    ->orderByAsc('id')
                     ->count();
             },
             3,
@@ -494,8 +492,8 @@ class QueryTest extends TestCase
                     ->seekable()
                     ->exclusive()
                     ->limit(3)
-                    ->orderAsc('modified')
-                    ->orderAsc('id')
+                    ->orderByAsc('modified')
+                    ->orderByAsc('id')
                     ->count();
             },
             3,
@@ -508,11 +506,11 @@ class QueryTest extends TestCase
                     ->backward()
                     ->seekable()
                     ->limit(3)
-                    ->orderAsc('modified')
-                    ->orderAsc('id')
+                    ->orderByAsc('modified')
+                    ->orderByAsc('id')
                     ->cursor([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ])
                     ->count();
             },
@@ -527,11 +525,11 @@ class QueryTest extends TestCase
                     ->seekable()
                     ->exclusive()
                     ->limit(3)
-                    ->orderAsc('modified')
-                    ->orderAsc('id')
+                    ->orderByAsc('modified')
+                    ->orderByAsc('id')
                     ->cursor([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ])
                     ->count();
             },
@@ -545,8 +543,8 @@ class QueryTest extends TestCase
                     ->forward()
                     ->seekable()
                     ->limit(3)
-                    ->orderDesc('modified')
-                    ->orderDesc('id')
+                    ->orderByDesc('modified')
+                    ->orderByDesc('id')
                     ->count();
             },
             3,
@@ -560,8 +558,8 @@ class QueryTest extends TestCase
                     ->seekable()
                     ->exclusive()
                     ->limit(3)
-                    ->orderDesc('modified')
-                    ->orderDesc('id')
+                    ->orderByDesc('modified')
+                    ->orderByDesc('id')
                     ->count();
             },
             3,
@@ -574,11 +572,11 @@ class QueryTest extends TestCase
                     ->forward()
                     ->seekable()
                     ->limit(3)
-                    ->orderDesc('modified')
-                    ->orderDesc('id')
+                    ->orderByDesc('modified')
+                    ->orderByDesc('id')
                     ->cursor([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ])
                     ->count();
             },
@@ -593,11 +591,11 @@ class QueryTest extends TestCase
                     ->seekable()
                     ->exclusive()
                     ->limit(3)
-                    ->orderDesc('modified')
-                    ->orderDesc('id')
+                    ->orderByDesc('modified')
+                    ->orderByDesc('id')
                     ->cursor([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ])
                     ->count();
             },
@@ -611,8 +609,8 @@ class QueryTest extends TestCase
                     ->backward()
                     ->seekable()
                     ->limit(3)
-                    ->orderDesc('modified')
-                    ->orderDesc('id')
+                    ->orderByDesc('modified')
+                    ->orderByDesc('id')
                     ->count();
             },
             3,
@@ -626,8 +624,8 @@ class QueryTest extends TestCase
                     ->seekable()
                     ->exclusive()
                     ->limit(3)
-                    ->orderDesc('modified')
-                    ->orderDesc('id')
+                    ->orderByDesc('modified')
+                    ->orderByDesc('id')
                     ->count();
             },
             3,
@@ -640,11 +638,11 @@ class QueryTest extends TestCase
                     ->backward()
                     ->seekable()
                     ->limit(3)
-                    ->orderDesc('modified')
-                    ->orderDesc('id')
+                    ->orderByDesc('modified')
+                    ->orderByDesc('id')
                     ->cursor([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ])
                     ->count();
             },
@@ -659,11 +657,11 @@ class QueryTest extends TestCase
                     ->seekable()
                     ->exclusive()
                     ->limit(3)
-                    ->orderDesc('modified')
-                    ->orderDesc('id')
+                    ->orderByDesc('modified')
+                    ->orderByDesc('id')
                     ->cursor([
                         'id' => 3,
-                        'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                        'modified' => new DateTime('2017-01-01 10:00:00'),
                     ])
                     ->count();
             },

--- a/tests/TestCase/PaginationResultTest.php
+++ b/tests/TestCase/PaginationResultTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Lampager\Cake\Test\TestCase;
 
 use ArrayIterator;
-use Cake\I18n\FrozenTime;
+use Cake\I18n\DateTime;
 use Cake\ORM\Entity;
 use Generator;
 use IteratorAggregate;
@@ -40,29 +40,10 @@ class PaginationResultTest extends TestCase
      * @dataProvider arrayProvider
      * @dataProvider iteratorAggregateProvider
      */
-    public function testIteratorCurrent(array $entities, $records, array $meta): void
+    public function testCurrentPage(array $entities, $records, array $meta): void
     {
         $actual = new PaginationResult($records, $meta);
-
-        $this->assertEquals($entities[0], $actual->current());
-
-        $actual->next();
-        $this->assertTrue($actual->valid());
-        $this->assertEquals(1, $actual->key());
-        $this->assertEquals($entities[1], $actual->current());
-
-        $actual->next();
-        $this->assertTrue($actual->valid());
-        $this->assertEquals(2, $actual->key());
-        $this->assertEquals($entities[2], $actual->current());
-
-        $actual->next();
-        $this->assertFalse($actual->valid());
-
-        $actual->rewind();
-        $this->assertTrue($actual->valid());
-        $this->assertEquals(0, $actual->key());
-        $this->assertEquals($entities[0], $actual->current());
+        $this->assertEquals(0, $actual->currentPage());
     }
 
     /**
@@ -72,29 +53,10 @@ class PaginationResultTest extends TestCase
      * @dataProvider arrayProvider
      * @dataProvider iteratorAggregateProvider
      */
-    public function testIteratorKey(array $entities, $records, array $meta): void
+    public function testPerPage(array $entities, $records, array $meta): void
     {
         $actual = new PaginationResult($records, $meta);
-
-        $this->assertEquals(0, $actual->key());
-
-        $actual->next();
-        $this->assertTrue($actual->valid());
-        $this->assertEquals(1, $actual->key());
-        $this->assertEquals($entities[1], $actual->current());
-
-        $actual->next();
-        $this->assertTrue($actual->valid());
-        $this->assertEquals(2, $actual->key());
-        $this->assertEquals($entities[2], $actual->current());
-
-        $actual->next();
-        $this->assertFalse($actual->valid());
-
-        $actual->rewind();
-        $this->assertTrue($actual->valid());
-        $this->assertEquals(0, $actual->key());
-        $this->assertEquals($entities[0], $actual->current());
+        $this->assertEquals(3, $actual->perPage());
     }
 
     /**
@@ -104,27 +66,10 @@ class PaginationResultTest extends TestCase
      * @dataProvider arrayProvider
      * @dataProvider iteratorAggregateProvider
      */
-    public function testIteratorNext(array $entities, $records, array $meta): void
+    public function testTotalCount(array $entities, $records, array $meta): void
     {
         $actual = new PaginationResult($records, $meta);
-
-        $actual->next();
-        $this->assertTrue($actual->valid());
-        $this->assertEquals(1, $actual->key());
-        $this->assertEquals($entities[1], $actual->current());
-
-        $actual->next();
-        $this->assertTrue($actual->valid());
-        $this->assertEquals(2, $actual->key());
-        $this->assertEquals($entities[2], $actual->current());
-
-        $actual->next();
-        $this->assertFalse($actual->valid());
-
-        $actual->rewind();
-        $this->assertTrue($actual->valid());
-        $this->assertEquals(0, $actual->key());
-        $this->assertEquals($entities[0], $actual->current());
+        $this->assertNull($actual->totalCount());
     }
 
     /**
@@ -134,31 +79,70 @@ class PaginationResultTest extends TestCase
      * @dataProvider arrayProvider
      * @dataProvider iteratorAggregateProvider
      */
-    public function testIteratorValid(array $entities, $records, array $meta): void
+    public function testPageCount(array $entities, $records, array $meta): void
     {
         $actual = new PaginationResult($records, $meta);
+        $this->assertNull($actual->pageCount());
+    }
 
-        $this->assertTrue($actual->valid());
-        $this->assertEquals(0, $actual->key());
-        $this->assertEquals($entities[0], $actual->current());
+    /**
+     * @param Entity[]                     $entities
+     * @param Entity[]|Traversable<Entity> $records
+     * @param mixed[]                      $meta
+     * @dataProvider arrayProvider
+     * @dataProvider iteratorAggregateProvider
+     */
+    public function testHasPrevPage(array $entities, $records, array $meta): void
+    {
+        $actual = new PaginationResult($records, $meta);
+        $this->assertEquals((bool)$meta['hasPrevious'], $actual->hasPrevPage());
+    }
 
-        $actual->next();
-        $this->assertTrue($actual->valid());
-        $this->assertEquals(1, $actual->key());
-        $this->assertEquals($entities[1], $actual->current());
+    /**
+     * @param Entity[]                     $entities
+     * @param Entity[]|Traversable<Entity> $records
+     * @param mixed[]                      $meta
+     * @dataProvider arrayProvider
+     * @dataProvider iteratorAggregateProvider
+     */
+    public function testHasNextPage(array $entities, $records, array $meta): void
+    {
+        $actual = new PaginationResult($records, $meta);
+        $this->assertEquals((bool)$meta['hasNext'], $actual->hasNextPage());
+    }
 
-        $actual->next();
-        $this->assertTrue($actual->valid());
-        $this->assertEquals(2, $actual->key());
-        $this->assertEquals($entities[2], $actual->current());
+    /**
+     * @param Entity[]                     $entities
+     * @param Entity[]|Traversable<Entity> $records
+     * @param mixed[]                      $meta
+     * @dataProvider arrayProvider
+     * @dataProvider iteratorAggregateProvider
+     */
+    public function testItems(array $entities, $records, array $meta): void
+    {
+        $paginationResult = new PaginationResult($records, $meta);
+        $expected = is_array($records) ? $records : iterator_to_array($records);
+        $actual = is_array($paginationResult->items()) ? $paginationResult->items() : iterator_to_array($paginationResult->items());
+        $this->assertEquals($expected, $actual);
+    }
 
-        $actual->next();
-        $this->assertFalse($actual->valid());
-
-        $actual->rewind();
-        $this->assertTrue($actual->valid());
-        $this->assertEquals(0, $actual->key());
-        $this->assertEquals($entities[0], $actual->current());
+    /**
+     * @param Entity[]                     $entities
+     * @param Entity[]|Traversable<Entity> $records
+     * @param mixed[]                      $meta
+     * @dataProvider arrayProvider
+     * @dataProvider iteratorAggregateProvider
+     */
+    public function testPagingParam(array $entities, $records, array $meta): void
+    {
+        $actual = new PaginationResult($records, $meta);
+        $this->assertEquals(count($entities), $actual->pagingParam('count'));
+        $this->assertNull($actual->pagingParam('totalCount'));
+        $this->assertEquals($meta['limit'], $actual->pagingParam('perPage'));
+        $this->assertNull($actual->pagingParam('pageCount'));
+        $this->assertEquals(0, $actual->pagingParam('currentPage'));
+        $this->assertEquals($meta['hasPrevious'], $actual->pagingParam('hasPrevPage'));
+        $this->assertEquals($meta['hasNext'], $actual->pagingParam('hasNextPage'));
     }
 
     /**
@@ -172,20 +156,6 @@ class PaginationResultTest extends TestCase
     {
         $actual = json_encode(new PaginationResult($records, $meta));
         $this->assertJsonStringEqualsJsonString($expected, $actual);
-    }
-
-    /**
-     * @param Entity[]                     $entities
-     * @param Entity[]|Traversable<Entity> $records
-     * @param mixed[]                      $meta
-     * @dataProvider arrayProvider
-     * @dataProvider iteratorAggregateProvider
-     */
-    public function testSerializeAndUnserialize(array $entities, $records, array $meta): void
-    {
-        $actual = unserialize(serialize(new PaginationResult($records, $meta)));
-        $expected = new PaginationResult($records, $meta);
-        $this->assertJsonEquals($expected, $actual);
     }
 
     /**
@@ -226,51 +196,35 @@ class PaginationResultTest extends TestCase
         $this->assertEquals($meta['nextCursor'], $paginationResult->nextCursor);
     }
 
-    /**
-     * @param Entity[]                     $entities
-     * @param Entity[]|Traversable<Entity> $records
-     * @param mixed[]                      $meta
-     * @dataProvider arrayProvider
-     * @dataProvider iteratorAggregateProvider
-     */
-    public function testUndefinedProperties(array $entities, $records, array $meta): void
-    {
-        $this->expectException(\ErrorException::class);
-        $this->expectExceptionMessageMatches('/^Undefined property via __get\(\): undefinedProperty/');
-
-        $paginationResult = new PaginationResult($records, $meta);
-        $paginationResult->undefinedProperty;
-    }
-
-    public function arrayProvider(): Generator
+    public static function arrayProvider(): Generator
     {
         yield 'Array iteration' => [
             [
                 new Entity([
                     'id' => 1,
-                    'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                    'modified' => new DateTime('2017-01-01 10:00:00'),
                 ]),
                 new Entity([
                     'id' => 3,
-                    'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                    'modified' => new DateTime('2017-01-01 10:00:00'),
                 ]),
                 new Entity([
                     'id' => 5,
-                    'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                    'modified' => new DateTime('2017-01-01 10:00:00'),
                 ]),
             ],
             [
                 new Entity([
                     'id' => 1,
-                    'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                    'modified' => new DateTime('2017-01-01 10:00:00'),
                 ]),
                 new Entity([
                     'id' => 3,
-                    'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                    'modified' => new DateTime('2017-01-01 10:00:00'),
                 ]),
                 new Entity([
                     'id' => 5,
-                    'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                    'modified' => new DateTime('2017-01-01 10:00:00'),
                 ]),
             ],
             [
@@ -279,8 +233,9 @@ class PaginationResultTest extends TestCase
                 'hasNext' => true,
                 'nextCursor' => [
                     'Posts.id' => 2,
-                    'Posts.modified' => new FrozenTime('2017-01-01 11:00:00'),
+                    'Posts.modified' => new DateTime('2017-01-01 11:00:00'),
                 ],
+                'limit' => 3,
             ],
             '{
                 "records": [
@@ -311,29 +266,29 @@ class PaginationResultTest extends TestCase
             [
                 new Entity([
                     'id' => 1,
-                    'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                    'modified' => new DateTime('2017-01-01 10:00:00'),
                 ]),
                 new Entity([
                     'id' => 3,
-                    'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                    'modified' => new DateTime('2017-01-01 10:00:00'),
                 ]),
                 new Entity([
                     'id' => 5,
-                    'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                    'modified' => new DateTime('2017-01-01 10:00:00'),
                 ]),
             ],
             new ArrayIterator([
                 new Entity([
                     'id' => 1,
-                    'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                    'modified' => new DateTime('2017-01-01 10:00:00'),
                 ]),
                 new Entity([
                     'id' => 3,
-                    'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                    'modified' => new DateTime('2017-01-01 10:00:00'),
                 ]),
                 new Entity([
                     'id' => 5,
-                    'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                    'modified' => new DateTime('2017-01-01 10:00:00'),
                 ]),
             ]),
             [
@@ -342,8 +297,9 @@ class PaginationResultTest extends TestCase
                 'hasNext' => true,
                 'nextCursor' => [
                     'Posts.id' => 2,
-                    'Posts.modified' => new FrozenTime('2017-01-01 11:00:00'),
+                    'Posts.modified' => new DateTime('2017-01-01 11:00:00'),
                 ],
+                'limit' => 3,
             ],
             '{
                 "records": [
@@ -371,21 +327,21 @@ class PaginationResultTest extends TestCase
         ];
     }
 
-    public function iteratorAggregateProvider(): Generator
+    public static function iteratorAggregateProvider(): Generator
     {
         yield 'IteratorAggregate iteration' => [
             [
                 new Entity([
                     'id' => 1,
-                    'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                    'modified' => new DateTime('2017-01-01 10:00:00'),
                 ]),
                 new Entity([
                     'id' => 3,
-                    'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                    'modified' => new DateTime('2017-01-01 10:00:00'),
                 ]),
                 new Entity([
                     'id' => 5,
-                    'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                    'modified' => new DateTime('2017-01-01 10:00:00'),
                 ]),
             ],
             new class implements IteratorAggregate {
@@ -394,15 +350,15 @@ class PaginationResultTest extends TestCase
                     return new ArrayIterator([
                         new Entity([
                             'id' => 1,
-                            'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                            'modified' => new DateTime('2017-01-01 10:00:00'),
                         ]),
                         new Entity([
                             'id' => 3,
-                            'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                            'modified' => new DateTime('2017-01-01 10:00:00'),
                         ]),
                         new Entity([
                             'id' => 5,
-                            'modified' => new FrozenTime('2017-01-01 10:00:00'),
+                            'modified' => new DateTime('2017-01-01 10:00:00'),
                         ]),
                     ]);
                 }
@@ -413,8 +369,9 @@ class PaginationResultTest extends TestCase
                 'hasNext' => true,
                 'nextCursor' => [
                     'Posts.id' => 2,
-                    'Posts.modified' => new FrozenTime('2017-01-01 11:00:00'),
+                    'Posts.modified' => new DateTime('2017-01-01 11:00:00'),
                 ],
+                'limit' => 3,
             ],
             '{
                 "records": [

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,15 +2,18 @@
 
 declare(strict_types=1);
 
+use function Cake\Core\env;
+use Cake\Core\Configure;
 use Cake\Database\Connection;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\Fixture\SchemaLoader;
 use Lampager\Cake\Database\Driver\Sqlite;
 
-require_once __DIR__ . '/../vendor/cakephp/cakephp/src/basics.php';
 require_once __DIR__ . '/../vendor/autoload.php';
 
 define('ROOT', dirname(__DIR__));
+
+Configure::write('App.encoding', 'utf-8');
 
 ConnectionManager::setConfig('test', [
     'url' => env('DB_DSN') ?: 'sqlite:///:memory:?className=' . Connection::class . '&driver=' . Sqlite::class . '&quoteIdentifiers=true',


### PR DESCRIPTION
This PR supports CakePHP 5.x, which is backward incompatible release with CakePHP 4.x. As CakePHP plugins cannot support multiple major versions of CakePHP, this is going to be separately maintained from the 2.x (for CakePHP 4.x).