### PR TITLE
Update requirement to cakephp/cakephp@^5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Rapid pagination without using OFFSET
 ## Requirements
 
 - PHP: ^8.1
-- CakePHP: ^5.0
+- CakePHP: ^5.1
 - [lampager/lampager][]: ^0.4
 
 ### Note
@@ -170,7 +170,7 @@ See also: [lampager/lampager][].
 | Lampager\\Cake\\`Paginator`                         | Class | Lampager\\`Paginator`                                                          | Paginator implementation for CakePHP                                                |
 | Lampager\\Cake\\`ArrayProcessor`                    | Class | Lampager\\`ArrayProcessor`                                                     | Processor implementation for CakePHP                                                |
 | Lampager\\Cake\\`PaginationResult`                  | Class | Lampager\\`PaginationResult`<br>Cake\\Datasource\\Paging\\`PaginatedInterface` | PaginationResult implementation for CakePHP                                         |
-| Lampager\\Cake\\Database\\`SqliteCompiler`          | Class | Cake\\Database\\`SqliteCompiler`                                               | Query compiler implementation for SQLite                                            |
+| Lampager\\Cake\\Database\\`SqliteCompiler`          | Class | Cake\\Database\\`QueryCompiler`                                                | Query compiler implementation for SQLite                                            |
 | Lampager\\Cake\\Database\\Driver\\`Sqlite`          | Class | Cake\\Database\\Driver\\`Sqlite`                                               | Driver implementation which delegates to Lampager\\Cake\\Database\\`SqliteCompiler` |
 
 ## API

--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,11 @@
     },
     "require": {
         "php": "^8.1",
-        "cakephp/cakephp": "^5.0",
+        "cakephp/cakephp": "^5.1",
         "lampager/lampager": "^0.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.1",
+        "phpunit/phpunit": "^10.1 || ^11.0",
         "nilportugues/sql-query-formatter": "^1.2"
     },
     "scripts": {

--- a/src/Database/SqliteCompiler.php
+++ b/src/Database/SqliteCompiler.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Lampager\Cake\Database;
 
 use Cake\Database\Query;
-use Cake\Database\SqliteCompiler as BaseSqliteCompiler;
+use Cake\Database\QueryCompiler;
 use Cake\Database\ValueBinder;
 
-class SqliteCompiler extends BaseSqliteCompiler
+class SqliteCompiler extends QueryCompiler
 {
     /**
      * {@inheritdoc}

--- a/tests/TestCase/Datasource/PaginatorTest.php
+++ b/tests/TestCase/Datasource/PaginatorTest.php
@@ -18,6 +18,7 @@ use Lampager\Cake\Model\Behavior\LampagerBehavior;
 use Lampager\Cake\PaginationResult;
 use Lampager\Cake\Test\TestCase\TestCase;
 use Lampager\Exceptions\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class PaginatorTest extends TestCase
@@ -26,10 +27,8 @@ class PaginatorTest extends TestCase
         'plugin.Lampager\\Cake.Posts',
     ];
 
-    /**
-     * @dataProvider valueProvider
-     * @dataProvider queryExpressionProvider
-     */
+    #[DataProvider('valueProvider')]
+    #[DataProvider('queryExpressionProvider')]
     public function testPaginateTable(callable $factory, PaginationResult $expected): void
     {
         $controller = new class(new ServerRequest()) extends Controller {
@@ -48,10 +47,8 @@ class PaginatorTest extends TestCase
         $this->assertJsonEquals($expected, $controller->paginate('Posts', $options));
     }
 
-    /**
-     * @dataProvider valueProvider
-     * @dataProvider queryExpressionProvider
-     */
+    #[DataProvider('valueProvider')]
+    #[DataProvider('queryExpressionProvider')]
     public function testPaginateTableFinder(callable $factory, PaginationResult $expected): void
     {
         $controller = new class(new ServerRequest()) extends Controller {
@@ -74,10 +71,8 @@ class PaginatorTest extends TestCase
         $this->assertJsonEquals($expected, $controller->paginate('Posts', $options));
     }
 
-    /**
-     * @dataProvider valueProvider
-     * @dataProvider queryExpressionProvider
-     */
+    #[DataProvider('valueProvider')]
+    #[DataProvider('queryExpressionProvider')]
     public function testPaginateCakeQuery(callable $factory, PaginationResult $expected): void
     {
         $controller = new class(new ServerRequest()) extends Controller {
@@ -96,10 +91,8 @@ class PaginatorTest extends TestCase
         $this->assertJsonEquals($expected, $controller->paginate($posts->find('all'), $options));
     }
 
-    /**
-     * @dataProvider valueProvider
-     * @dataProvider queryExpressionProvider
-     */
+    #[DataProvider('valueProvider')]
+    #[DataProvider('queryExpressionProvider')]
     public function testPaginateExtraSettings(callable $factory): void
     {
         $controller = new class(new ServerRequest()) extends Controller {
@@ -122,10 +115,8 @@ class PaginatorTest extends TestCase
         });
     }
 
-    /**
-     * @dataProvider valueProvider
-     * @dataProvider queryExpressionProvider
-     */
+    #[DataProvider('valueProvider')]
+    #[DataProvider('queryExpressionProvider')]
     public function testPaginateLampagerCakeQuery(callable $factory): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/TestCase/Model/ArrayProcessorTest.php
+++ b/tests/TestCase/Model/ArrayProcessorTest.php
@@ -13,6 +13,7 @@ use Lampager\Cake\ORM\Query;
 use Lampager\Cake\PaginationResult;
 use Lampager\Cake\Paginator;
 use Lampager\Cake\Test\TestCase\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class ArrayProcessorTest extends TestCase
@@ -21,8 +22,8 @@ class ArrayProcessorTest extends TestCase
      * @param mixed[]  $options
      * @param ?mixed[] $cursor
      * @param Entity[] $rows
-     * @dataProvider processProvider
      */
+    #[DataProvider('processProvider')]
     public function testProcess(array $options, ?array $cursor, array $rows, PaginationResult $expected): void
     {
         /** @var MockObject&Table $repository */

--- a/tests/TestCase/Model/Behavior/LampagerBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/LampagerBehaviorTest.php
@@ -13,6 +13,7 @@ use Lampager\Cake\Model\Behavior\LampagerBehavior;
 use Lampager\Cake\ORM\Query;
 use Lampager\Cake\Test\TestCase\TestCase;
 use Lampager\PaginationResult;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class LampagerBehaviorTest extends TestCase
 {
@@ -20,10 +21,8 @@ class LampagerBehaviorTest extends TestCase
         'plugin.Lampager\\Cake.Posts',
     ];
 
-    /**
-     * @dataProvider valueProvider
-     * @dataProvider queryExpressionProvider
-     */
+    #[DataProvider('valueProvider')]
+    #[DataProvider('queryExpressionProvider')]
     public function testLampager(callable $factory, PaginationResult $expected): void
     {
         /** @var LampagerBehavior&Table $posts */

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -19,6 +19,7 @@ use Lampager\Contracts\Exceptions\LampagerException;
 use Lampager\Exceptions\Query\BadKeywordException;
 use Lampager\Exceptions\Query\InsufficientConstraintsException;
 use Lampager\Exceptions\Query\LimitParameterException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class QueryTest extends TestCase
@@ -46,10 +47,8 @@ class QueryTest extends TestCase
         parent::tearDown();
     }
 
-    /**
-     * @dataProvider orderProvider
-     */
-    public function testorderBy(callable $factory, PaginationResult $expected): void
+    #[DataProvider('orderProvider')]
+    public function testOrderBy(callable $factory, PaginationResult $expected): void
     {
         /** @var LampagerBehavior&Table $posts */
         $posts = TableRegistry::getTableLocator()->get('Posts');
@@ -60,9 +59,7 @@ class QueryTest extends TestCase
         $this->assertJsonEquals($expected, $query->paginate());
     }
 
-    /**
-     * @dataProvider orderProvider
-     */
+    #[DataProvider('orderProvider')]
     public function testOrderClear(callable $factory): void
     {
         $this->expectException(LampagerException::class);
@@ -309,9 +306,7 @@ class QueryTest extends TestCase
         $this->assertArrayHasKey('extraOptions', $actual);
     }
 
-    /**
-     * @dataProvider countProvider
-     */
+    #[DataProvider('countProvider')]
     public function testCount(callable $factory, int $expected): void
     {
         /** @var LampagerBehavior&Table $posts */

--- a/tests/TestCase/PaginationResultTest.php
+++ b/tests/TestCase/PaginationResultTest.php
@@ -10,6 +10,7 @@ use Cake\ORM\Entity;
 use Generator;
 use IteratorAggregate;
 use Lampager\Cake\PaginationResult;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Traversable;
 
 class PaginationResultTest extends TestCase
@@ -37,9 +38,9 @@ class PaginationResultTest extends TestCase
      * @param Entity[]                     $entities
      * @param Entity[]|Traversable<Entity> $records
      * @param mixed[]                      $meta
-     * @dataProvider arrayProvider
-     * @dataProvider iteratorAggregateProvider
      */
+    #[DataProvider('arrayProvider')]
+    #[DataProvider('iteratorAggregateProvider')]
     public function testCurrentPage(array $entities, $records, array $meta): void
     {
         $actual = new PaginationResult($records, $meta);
@@ -50,9 +51,9 @@ class PaginationResultTest extends TestCase
      * @param Entity[]                     $entities
      * @param Entity[]|Traversable<Entity> $records
      * @param mixed[]                      $meta
-     * @dataProvider arrayProvider
-     * @dataProvider iteratorAggregateProvider
      */
+    #[DataProvider('arrayProvider')]
+    #[DataProvider('iteratorAggregateProvider')]
     public function testPerPage(array $entities, $records, array $meta): void
     {
         $actual = new PaginationResult($records, $meta);
@@ -63,9 +64,9 @@ class PaginationResultTest extends TestCase
      * @param Entity[]                     $entities
      * @param Entity[]|Traversable<Entity> $records
      * @param mixed[]                      $meta
-     * @dataProvider arrayProvider
-     * @dataProvider iteratorAggregateProvider
      */
+    #[DataProvider('arrayProvider')]
+    #[DataProvider('iteratorAggregateProvider')]
     public function testTotalCount(array $entities, $records, array $meta): void
     {
         $actual = new PaginationResult($records, $meta);
@@ -76,9 +77,9 @@ class PaginationResultTest extends TestCase
      * @param Entity[]                     $entities
      * @param Entity[]|Traversable<Entity> $records
      * @param mixed[]                      $meta
-     * @dataProvider arrayProvider
-     * @dataProvider iteratorAggregateProvider
      */
+    #[DataProvider('arrayProvider')]
+    #[DataProvider('iteratorAggregateProvider')]
     public function testPageCount(array $entities, $records, array $meta): void
     {
         $actual = new PaginationResult($records, $meta);
@@ -89,9 +90,9 @@ class PaginationResultTest extends TestCase
      * @param Entity[]                     $entities
      * @param Entity[]|Traversable<Entity> $records
      * @param mixed[]                      $meta
-     * @dataProvider arrayProvider
-     * @dataProvider iteratorAggregateProvider
      */
+    #[DataProvider('arrayProvider')]
+    #[DataProvider('iteratorAggregateProvider')]
     public function testHasPrevPage(array $entities, $records, array $meta): void
     {
         $actual = new PaginationResult($records, $meta);
@@ -102,9 +103,9 @@ class PaginationResultTest extends TestCase
      * @param Entity[]                     $entities
      * @param Entity[]|Traversable<Entity> $records
      * @param mixed[]                      $meta
-     * @dataProvider arrayProvider
-     * @dataProvider iteratorAggregateProvider
      */
+    #[DataProvider('arrayProvider')]
+    #[DataProvider('iteratorAggregateProvider')]
     public function testHasNextPage(array $entities, $records, array $meta): void
     {
         $actual = new PaginationResult($records, $meta);
@@ -115,9 +116,9 @@ class PaginationResultTest extends TestCase
      * @param Entity[]                     $entities
      * @param Entity[]|Traversable<Entity> $records
      * @param mixed[]                      $meta
-     * @dataProvider arrayProvider
-     * @dataProvider iteratorAggregateProvider
      */
+    #[DataProvider('arrayProvider')]
+    #[DataProvider('iteratorAggregateProvider')]
     public function testItems(array $entities, $records, array $meta): void
     {
         $paginationResult = new PaginationResult($records, $meta);
@@ -130,9 +131,9 @@ class PaginationResultTest extends TestCase
      * @param Entity[]                     $entities
      * @param Entity[]|Traversable<Entity> $records
      * @param mixed[]                      $meta
-     * @dataProvider arrayProvider
-     * @dataProvider iteratorAggregateProvider
      */
+    #[DataProvider('arrayProvider')]
+    #[DataProvider('iteratorAggregateProvider')]
     public function testPagingParam(array $entities, $records, array $meta): void
     {
         $actual = new PaginationResult($records, $meta);
@@ -149,9 +150,9 @@ class PaginationResultTest extends TestCase
      * @param Entity[]                     $entities
      * @param Entity[]|Traversable<Entity> $records
      * @param mixed[]                      $meta
-     * @dataProvider arrayProvider
-     * @dataProvider iteratorAggregateProvider
      */
+    #[DataProvider('arrayProvider')]
+    #[DataProvider('iteratorAggregateProvider')]
     public function testJsonSerialize(array $entities, $records, array $meta, string $expected): void
     {
         $actual = json_encode(new PaginationResult($records, $meta));
@@ -162,9 +163,9 @@ class PaginationResultTest extends TestCase
      * @param Entity[]                     $entities
      * @param Entity[]|Traversable<Entity> $records
      * @param mixed[]                      $meta
-     * @dataProvider arrayProvider
-     * @dataProvider iteratorAggregateProvider
      */
+    #[DataProvider('arrayProvider')]
+    #[DataProvider('iteratorAggregateProvider')]
     public function testDebugInfo(array $entities, $records, array $meta): void
     {
         $actual = (new PaginationResult($records, $meta))->__debugInfo();
@@ -183,9 +184,9 @@ class PaginationResultTest extends TestCase
      * @param Entity[]                     $entities
      * @param Entity[]|Traversable<Entity> $records
      * @param mixed[]                      $meta
-     * @dataProvider arrayProvider
-     * @dataProvider iteratorAggregateProvider
      */
+    #[DataProvider('arrayProvider')]
+    #[DataProvider('iteratorAggregateProvider')]
     public function testPublicProperties(array $entities, $records, array $meta): void
     {
         $paginationResult = new PaginationResult($records, $meta);


### PR DESCRIPTION
The parent class of `Lampager\Cake\Database\SqliteCompiler`, `Cake\Database\SqliteCompiler`, has been replaced with `Cake\Database\QueryCompiler` as it was removed in CakePHP 5.1.