### PR TITLE
Add support for Lampager 0.5 (backport)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "cakephp/cakephp": "^4.5",
-        "lampager/lampager": "^0.4"
+        "lampager/lampager": "^0.4 || ^0.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0 || ^9.0",


### PR DESCRIPTION
Back port #52 for v2.x (CakePHP 4.x)